### PR TITLE
Clean up flow logging and trace logging

### DIFF
--- a/benchmarks/src/main/scala/com/tersesystems/echopraxia/benchmarks/TraceLoggerBenchmarks.scala
+++ b/benchmarks/src/main/scala/com/tersesystems/echopraxia/benchmarks/TraceLoggerBenchmarks.scala
@@ -9,8 +9,8 @@ import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 @State(Scope.Benchmark)
 class TraceLoggerBenchmarks {
@@ -19,6 +19,34 @@ class TraceLoggerBenchmarks {
   @Benchmark
   def info(blackhole: Blackhole): Unit = {
     val result = logger.info {
+      "some string"
+    }
+    blackhole.consume(result)
+  }
+
+  @Benchmark
+  def infoWithCondition(blackhole: Blackhole): Unit = {
+    // should fail condition without ever having to resolve fields,
+    // so much faster (although still slower than a level check or "Condition.never")
+    val result = logger.info(condition) {
+      "some string"
+    }
+    blackhole.consume(result)
+  }
+
+  @Benchmark
+  def infoWithFieldsCondition(blackhole: Blackhole): Unit = {
+    // this should about the same speed as info because fields
+    // are memoized
+    val result = logger.info(fieldsCondition) {
+      "some string"
+    }
+    blackhole.consume(result)
+  }
+
+  @Benchmark
+  def traceWithCondition(blackhole: Blackhole): Unit = {
+    val result = logger.trace(condition) {
       "some string"
     }
     blackhole.consume(result)
@@ -44,6 +72,10 @@ class TraceLoggerBenchmarks {
 
 object TraceLoggerBenchmarks {
   private val logger = TraceLoggerFactory.getLogger
+
+  private val condition: Condition = (_, ctx) => false
+
+  private val fieldsCondition: Condition = (_, ctx) => ctx.findString("$.sourcecode.file").exists(s => s.endsWith("TraceLoggerBenchmarks.scala"))
 
   private val neverLogger = logger.withCondition(Condition.never)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.Keys._
 
-val echopraxiaVersion = "2.0.2-SNAPSHOT"
+val echopraxiaVersion = "2.1.0-SNAPSHOT"
 
 val scala213      = "2.13.8"
 val scala212      = "2.12.14"
@@ -53,10 +53,6 @@ lazy val logger = (project in file("logger"))
   .settings(
     name := "logger",
     //
-    run / fork := true,
-    //
-    libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.2.8",
-    //
     libraryDependencies += "com.tersesystems.echopraxia" % "logstash"  % echopraxiaVersion % Test,
     libraryDependencies += "org.scalatest"              %% "scalatest" % "3.2.12"      % Test
   )
@@ -82,7 +78,7 @@ lazy val flowLogger = (project in file("flow"))
 lazy val traceLogger = (project in file("trace"))
   .settings(
     name := "trace-logger",
-
+    //
     libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.2.8",
     //
     libraryDependencies += "com.tersesystems.echopraxia" % "logstash"  % echopraxiaVersion % Test,

--- a/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/DefaultFlowLoggerMethods.scala
+++ b/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/DefaultFlowLoggerMethods.scala
@@ -1,6 +1,6 @@
 package com.tersesystems.echopraxia.plusscala.flow
 
-import com.tersesystems.echopraxia.api.{FieldBuilderResult, Level => JLevel}
+import com.tersesystems.echopraxia.api.{FieldBuilderResult, LoggerHandle, Level => JLevel}
 import com.tersesystems.echopraxia.plusscala.api.{Condition, DefaultMethodsSupport}
 
 import java.util.function.Function
@@ -97,14 +97,14 @@ trait DefaultFlowLoggerMethods[FB <: FlowFieldBuilder] extends DefaultMethodsSup
 
   @inline
   private def execute[B: ToValue](level: JLevel, attempt: => B): B = {
-    core.log(level, fieldBuilder.enteringTemplate, entering, fieldBuilder)
-
+    val handle: LoggerHandle[FB] = core.logHandle(level, fieldBuilder);
+    handle.log(fieldBuilder.enteringTemplate, entering)
     val result = Try(attempt)
     result match {
       case Success(ret) =>
-        core.log(level, fieldBuilder.exitingTemplate, exiting(ret), fieldBuilder)
+        handle.log(fieldBuilder.exitingTemplate, exiting(ret))
       case Failure(ex) =>
-        core.log(level, fieldBuilder.throwingTemplate, throwing(ex), fieldBuilder)
+        handle.log(fieldBuilder.throwingTemplate, throwing(ex))
     }
     result.get // rethrow the exception
   }

--- a/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLogger.scala
+++ b/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLogger.scala
@@ -48,15 +48,15 @@ class FlowLogger[FB <: FlowFieldBuilder](core: CoreLogger, fieldBuilder: FB)
 
 object FlowLogger {
   final class NeverLogger[FB <: FlowFieldBuilder](core: CoreLogger, fieldBuilder: FB) extends FlowLogger[FB](core, fieldBuilder) {
-    override def trace[B: ToValue](attempt: => B): B = attempt
+    override def trace[B: ToValue](attempt: => B): B                       = attempt
     override def trace[B: ToValue](condition: Condition)(attempt: => B): B = attempt
-    override def debug[B: ToValue](attempt: => B): B = attempt
+    override def debug[B: ToValue](attempt: => B): B                       = attempt
     override def debug[B: ToValue](condition: Condition)(attempt: => B): B = attempt
-    override def info[B: ToValue](attempt: => B): B = attempt
-    override def info[B: ToValue](condition: Condition)(attempt: => B): B = attempt
-    override def warn[B: ToValue](attempt: => B): B = attempt
-    override def warn[B: ToValue](condition: Condition)(attempt: => B): B = attempt
-    override def error[B: ToValue](attempt: => B): B = attempt
+    override def info[B: ToValue](attempt: => B): B                        = attempt
+    override def info[B: ToValue](condition: Condition)(attempt: => B): B  = attempt
+    override def warn[B: ToValue](attempt: => B): B                        = attempt
+    override def warn[B: ToValue](condition: Condition)(attempt: => B): B  = attempt
+    override def error[B: ToValue](attempt: => B): B                       = attempt
     override def error[B: ToValue](condition: Condition)(attempt: => B): B = attempt
   }
 }

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/DefaultLoggerMethods.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/DefaultLoggerMethods.scala
@@ -337,7 +337,7 @@ trait DefaultLoggerMethods[FB] extends LoggerMethods[FB] {
 
   // -----------------------------------------------------------
   // Internal methods
-  
+
   @inline
   private def handleMessage(level: Level, message: String): Unit = {
     core.log(level, message)
@@ -365,10 +365,7 @@ trait DefaultLoggerMethods[FB] extends LoggerMethods[FB] {
 
   @inline
   private def handleConditionMessageThrowable(level: Level, condition: Condition, message: String, e: Throwable): Unit = {
-    core.log(level, condition.asJava, message,
-        (_: FB) => onlyException(e),
-        fieldBuilder
-      )
+    core.log(level, condition.asJava, message, (_: FB) => onlyException(e), fieldBuilder)
   }
 
   @inline

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
@@ -6,7 +6,6 @@ import com.tersesystems.echopraxia.plusscala.api.{AbstractLoggerSupport, Conditi
 import scala.compat.java8.FunctionConverters.enrichAsJavaFunction
 
 /**
- *
  */
 class Logger[FB](core: CoreLogger, fieldBuilder: FB)
     extends AbstractLoggerSupport(core, fieldBuilder)
@@ -48,49 +47,49 @@ class Logger[FB](core: CoreLogger, fieldBuilder: FB)
     new Logger[T](newCoreLogger, newFieldBuilder)
 
   class NeverLogger(core: CoreLogger, fieldBuilder: FB) extends Logger[FB](core: CoreLogger, fieldBuilder: FB) {
-    override def isTraceEnabled: Boolean                                                                                           = false
-    override def isTraceEnabled(condition: Condition): Boolean                                                                     = false
-    override def trace(message: String): Unit                                     = {}
-    override def trace(message: String, e: Throwable): Unit                       = {}
-    override def trace(message: String, f: FB => FieldBuilderResult): Unit        = {}
-    override def trace(condition: Condition, message: String): Unit               = {}
-    override def trace(condition: Condition, message: String, e: Throwable): Unit = {}
+    override def isTraceEnabled: Boolean                                                         = false
+    override def isTraceEnabled(condition: Condition): Boolean                                   = false
+    override def trace(message: String): Unit                                                    = {}
+    override def trace(message: String, e: Throwable): Unit                                      = {}
+    override def trace(message: String, f: FB => FieldBuilderResult): Unit                       = {}
+    override def trace(condition: Condition, message: String): Unit                              = {}
+    override def trace(condition: Condition, message: String, e: Throwable): Unit                = {}
     override def trace(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isDebugEnabled: Boolean                                                                                           = false
-    override def isDebugEnabled(condition: Condition): Boolean                                                                     = false
-    override def debug(message: String): Unit                                     = {}
-    override def debug(message: String, e: Throwable): Unit                       = {}
-    override def debug(message: String, f: FB => FieldBuilderResult): Unit        = {}
-    override def debug(condition: Condition, message: String): Unit               = {}
-    override def debug(condition: Condition, message: String, e: Throwable): Unit = {}
+    override def isDebugEnabled: Boolean                                                         = false
+    override def isDebugEnabled(condition: Condition): Boolean                                   = false
+    override def debug(message: String): Unit                                                    = {}
+    override def debug(message: String, e: Throwable): Unit                                      = {}
+    override def debug(message: String, f: FB => FieldBuilderResult): Unit                       = {}
+    override def debug(condition: Condition, message: String): Unit                              = {}
+    override def debug(condition: Condition, message: String, e: Throwable): Unit                = {}
     override def debug(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isInfoEnabled: Boolean                                                                                           = false
-    override def isInfoEnabled(condition: Condition): Boolean                                                                     = false
-    override def info(message: String): Unit                                     = {}
-    override def info(message: String, f: FB => FieldBuilderResult): Unit        = {}
-    override def info(message: String, e: Throwable): Unit                       = {}
-    override def info(condition: Condition, message: String): Unit               = {}
-    override def info(condition: Condition, message: String, e: Throwable): Unit = {}
+    override def isInfoEnabled: Boolean                                                         = false
+    override def isInfoEnabled(condition: Condition): Boolean                                   = false
+    override def info(message: String): Unit                                                    = {}
+    override def info(message: String, f: FB => FieldBuilderResult): Unit                       = {}
+    override def info(message: String, e: Throwable): Unit                                      = {}
+    override def info(condition: Condition, message: String): Unit                              = {}
+    override def info(condition: Condition, message: String, e: Throwable): Unit                = {}
     override def info(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isWarnEnabled: Boolean                                                                                           = false
-    override def isWarnEnabled(condition: Condition): Boolean                                                                     = false
-    override def warn(message: String): Unit                                     = {}
-    override def warn(message: String, f: FB => FieldBuilderResult): Unit        = {}
-    override def warn(message: String, e: Throwable): Unit                       = {}
-    override def warn(condition: Condition, message: String): Unit               = {}
-    override def warn(condition: Condition, message: String, e: Throwable): Unit = {}
+    override def isWarnEnabled: Boolean                                                         = false
+    override def isWarnEnabled(condition: Condition): Boolean                                   = false
+    override def warn(message: String): Unit                                                    = {}
+    override def warn(message: String, f: FB => FieldBuilderResult): Unit                       = {}
+    override def warn(message: String, e: Throwable): Unit                                      = {}
+    override def warn(condition: Condition, message: String): Unit                              = {}
+    override def warn(condition: Condition, message: String, e: Throwable): Unit                = {}
     override def warn(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isErrorEnabled: Boolean                                                                                           = false
-    override def isErrorEnabled(condition: Condition): Boolean                                                                     = false
-    override def error(message: String): Unit                                     = {}
-    override def error(message: String, f: FB => FieldBuilderResult): Unit        = {}
-    override def error(message: String, e: Throwable): Unit                       = {}
-    override def error(condition: Condition, message: String): Unit               = {}
-    override def error(condition: Condition, message: String, e: Throwable): Unit = {}
+    override def isErrorEnabled: Boolean                                                         = false
+    override def isErrorEnabled(condition: Condition): Boolean                                   = false
+    override def error(message: String): Unit                                                    = {}
+    override def error(message: String, f: FB => FieldBuilderResult): Unit                       = {}
+    override def error(message: String, e: Throwable): Unit                                      = {}
+    override def error(condition: Condition, message: String): Unit                              = {}
+    override def error(condition: Condition, message: String, e: Throwable): Unit                = {}
     override def error(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
   }
 }

--- a/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceFieldBuilder.scala
+++ b/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceFieldBuilder.scala
@@ -1,15 +1,11 @@
 package com.tersesystems.echopraxia.plusscala.trace
 
 import com.tersesystems.echopraxia.api.{Field, FieldBuilderResult, Value}
-import com.tersesystems.echopraxia.plusscala.api.{FieldBuilder, ValueTypeClasses}
+import com.tersesystems.echopraxia.plusscala.api.{FieldBuilder, ListToFieldBuilderResultMethods, ValueTypeClasses}
+import com.tersesystems.echopraxia.plusscala.trace.DefaultTraceFieldBuilder.{TraceArgumentValues, TraceSignature, string}
 import sourcecode._
 
-trait TraceFieldBuilder extends ValueTypeClasses {
-
-  trait SourceFields {
-    def argumentFields: Seq[Field]
-    def loggerFields: Seq[Field]
-  }
+trait TraceFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMethods {
 
   def sourceFields(implicit line: Line, file: File, enc: Enclosing, args: Args): SourceFields
 
@@ -19,68 +15,37 @@ trait TraceFieldBuilder extends ValueTypeClasses {
 
   def throwingTemplate: String
 
-  def entering(signature: TraceFieldBuilder#SourceFields): FieldBuilderResult
+  def entering(sourceFields: SourceFields): FieldBuilderResult
 
-  def exiting(signature: TraceFieldBuilder#SourceFields, value: Value[_]): FieldBuilderResult
+  def exiting(sourceFields: SourceFields, value: Value[_]): FieldBuilderResult
 
-  def throwing(signature: TraceFieldBuilder#SourceFields, ex: Throwable): FieldBuilderResult
+  def throwing(sourceFields: SourceFields, ex: Throwable): FieldBuilderResult
 }
 
 trait DefaultTraceFieldBuilder extends FieldBuilder with TraceFieldBuilder {
   import DefaultTraceFieldBuilder._
 
-  override val enteringTemplate: String = "{}: {}({})"
-
-  override val exitingTemplate: String = "{}: {}({}) => {}"
-
-  override val throwingTemplate: String = "{}: {}({}) ! {}"
-
-  override def entering(sourceFields: TraceFieldBuilder#SourceFields): FieldBuilderResult = {
+  override def entering(sourceFields: SourceFields): FieldBuilderResult = {
     list(Seq(entryTag) ++ sourceFields.argumentFields)
   }
 
-  override def exiting(sourceFields: TraceFieldBuilder#SourceFields, retValue: Value[_]): FieldBuilderResult = {
+  override def exiting(sourceFields: SourceFields, retValue: Value[_]): FieldBuilderResult = {
     list(Seq(exitTag) ++ sourceFields.argumentFields :+ value(TraceResult, retValue))
   }
 
-  override def throwing(signature: TraceFieldBuilder#SourceFields, ex: Throwable): FieldBuilderResult = {
-    list(Seq(throwingTag) ++ signature.argumentFields :+ exception(ex))
+  override def throwing(sourceFields: SourceFields, ex: Throwable): FieldBuilderResult = {
+    list(Seq(throwingTag) ++ sourceFields.argumentFields :+ exception(ex))
   }
 
-  override def sourceFields(implicit line: Line, file: File, enc: Enclosing, args: Args): SourceFields = new SourceFields {
-    def signature = s"${enc.value}(${args.value.map(argumentTypes).mkString(",")})"
-
-    def entryArguments(list: Seq[Text[_]]): String = {
-      list.map(_.value).mkString(",")
-    }
-
-    def argumentTypes(list: Seq[Text[_]]): String = {
-      list.map(txt => s"${txt.source}: ${txt.value.getClass.getSimpleName}").mkString(",")
-    }
-
-    override val argumentFields: Seq[Field] = Seq(
-      string(TraceSignature, signature),
-      string(TraceArgumentValues, args.value.map(list => entryArguments(list)).mkString(","))
-    )
-
-    override val loggerFields: Seq[Field] = {
-      // XXX since sourcecode data is static, we could cache the result given the inputs
-      // and save on some allocation.  Or would it be possible to turn this into a macro at
-      // and point to constant fields and values?
-      Seq(Field
-        .keyValue(
-          "sourcecode",
-          Value.`object`(
-            Field.keyValue("file", Value.string(file.value)),
-            Field.keyValue("line", Value.number(line.value: java.lang.Integer)),
-            Field.keyValue("enclosing", Value.string(enc.value))
-          )
-        ))
-    }
-  }
+  override def sourceFields(implicit line: Line, file: File, enc: Enclosing, args: Args): SourceFields =
+    new DefaultSourceFields(line, file, enc, args)
 }
 
 object DefaultTraceFieldBuilder extends DefaultTraceFieldBuilder {
+
+  override val enteringTemplate: String = "{}: {} - ({})"
+  override val exitingTemplate: String  = "{}: {} - ({}) => {}"
+  override val throwingTemplate: String = "{}: {} - ({}) ! {}"
 
   val TraceTag: String = "traceTag"
   val Entry: String    = "entry"
@@ -94,4 +59,44 @@ object DefaultTraceFieldBuilder extends DefaultTraceFieldBuilder {
   val entryTag: Field    = value(TraceTag, Entry)
   val exitTag: Field     = value(TraceTag, Exit)
   val throwingTag: Field = value(TraceTag, Throwing)
+}
+
+trait SourceFields {
+  def argumentFields: Seq[Field]
+
+  def loggerFields: Seq[Field]
+}
+
+class DefaultSourceFields(line: Line, file: File, enc: Enclosing, args: Args) extends SourceFields {
+  def signature = s"${enc.value}(${args.value.map(argumentTypes).mkString(",")})"
+
+  def entryArguments(list: Seq[Text[_]]): String = {
+    list.map(_.value).mkString(",")
+  }
+
+  def argumentTypes(list: Seq[Text[_]]): String = {
+    list.map(txt => s"${txt.source}: ${txt.value.getClass.getSimpleName}").mkString(",")
+  }
+
+  override lazy val argumentFields: Seq[Field] = Seq(
+    string(TraceSignature, signature),
+    string(TraceArgumentValues, args.value.map(list => entryArguments(list)).mkString(","))
+  )
+
+  override lazy val loggerFields: Seq[Field] = {
+    // XXX since sourcecode data is static, we could cache the result given the inputs
+    // and save on some allocation.  Or would it be possible to turn this into a macro at
+    // and point to constant fields and values?
+    Seq(
+      Field
+        .keyValue(
+          "sourcecode",
+          Value.`object`(
+            Field.keyValue("file", Value.string(file.value)),
+            Field.keyValue("line", Value.number(line.value: java.lang.Integer)),
+            Field.keyValue("enclosing", Value.string(enc.value))
+          )
+        )
+    )
+  }
 }

--- a/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceLogger.scala
+++ b/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceLogger.scala
@@ -49,15 +49,15 @@ class TraceLogger[FB <: TraceFieldBuilder](core: CoreLogger, fieldBuilder: FB)
 
 object TraceLogger {
   final class Never[FB <: TraceFieldBuilder](core: CoreLogger, fieldBuilder: FB) extends TraceLogger[FB](core, fieldBuilder) {
-    override def trace[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+    override def trace[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                       = attempt
     override def trace[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def debug[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+    override def debug[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                       = attempt
     override def debug[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def info[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def info[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def warn[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def warn[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def error[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+    override def info[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                        = attempt
+    override def info[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B  = attempt
+    override def warn[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                        = attempt
+    override def warn[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B  = attempt
+    override def error[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                       = attempt
     override def error[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
   }
 }


### PR DESCRIPTION
Use the handle methods in `2.1.0` for trace/flow logging, use `SourceFields` trait consistently, only include sourcecode for trace logging.