### PR TITLE
Remove AbstractLoggingSupport

### DIFF
--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/AbstractLoggerSupport.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/AbstractLoggerSupport.scala
@@ -1,7 +1,0 @@
-package com.tersesystems.echopraxia.plusscala.api
-
-import com.tersesystems.echopraxia.api.CoreLogger
-
-abstract class AbstractLoggerSupport[FB](val core: CoreLogger, val fieldBuilder: FB) extends DefaultMethodsSupport[FB] {
-  def name: String = core.getName
-}

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/LoggerSupport.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/LoggerSupport.scala
@@ -2,13 +2,13 @@ package com.tersesystems.echopraxia.plusscala.api
 
 import com.tersesystems.echopraxia.api.FieldBuilderResult
 
-trait LoggerSupport[FB] {
+trait LoggerSupport[FB, LoggerType[_ <: FB]] { self =>
 
-  def withCondition(scalaCondition: Condition): LoggerSupport[FB]
+  def withCondition(scalaCondition: Condition): LoggerType[FB]
 
-  def withFields(f: FB => FieldBuilderResult): LoggerSupport[FB]
+  def withFields(f: FB => FieldBuilderResult): LoggerType[FB]
 
-  def withThreadContext: LoggerSupport[FB]
+  def withThreadContext: LoggerType[FB]
 
-  def withFieldBuilder[T <: FB](newBuilder: T): LoggerSupport[T]
+  def withFieldBuilder[T <: FB](newBuilder: T): LoggerType[T]
 }

--- a/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLogger.scala
+++ b/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLogger.scala
@@ -1,99 +1,161 @@
 package com.tersesystems.echopraxia.plusscala.async
 
 import com.tersesystems.echopraxia.api.{CoreLogger, FieldBuilderResult, Utilities}
-import com.tersesystems.echopraxia.plusscala.api.{AbstractLoggerSupport, Condition, LoggerSupport}
+import com.tersesystems.echopraxia.plusscala.api.{Condition, DefaultMethodsSupport, LoggerSupport}
 
 import java.util.concurrent.Executor
 import scala.compat.java8.FunctionConverters._
 
-/**
- * Async Logger with source code enabled.
- */
-class AsyncLogger[FB](core: CoreLogger, fieldBuilder: FB)
-    extends AbstractLoggerSupport[FB](core, fieldBuilder)
-    with LoggerSupport[FB]
-    with DefaultAsyncLoggerMethods[FB] {
+trait AsyncLogger[FB] extends AsyncLoggerMethods[FB] with LoggerSupport[FB, AsyncLogger] with DefaultMethodsSupport[FB] {
+  def withExecutor(executor: Executor): AsyncLogger[FB]
+}
 
-  override def name: String = core.getName
+object AsyncLogger {
 
-  override def withCondition(scalaCondition: Condition): AsyncLogger[FB] = {
-    scalaCondition match {
-      case Condition.always =>
-        this
-      case Condition.never =>
-        new NeverAsyncLogger(core, fieldBuilder)
-      case other =>
-        newLogger(newCoreLogger = core.withCondition(other.asJava))
+  def apply[FB](core: CoreLogger, fieldBuilder: FB): AsyncLogger[FB] = new Impl(core, fieldBuilder)
+
+  /**
+   * Async Logger with source code enabled.
+   */
+  class Impl[FB](val core: CoreLogger, val fieldBuilder: FB) extends AsyncLogger[FB] with DefaultAsyncLoggerMethods[FB] {
+
+    override def name: String = core.getName
+
+    override def withCondition(scalaCondition: Condition): AsyncLogger[FB] = {
+      scalaCondition match {
+        case Condition.always =>
+          this
+        case Condition.never =>
+          NoOp(core, fieldBuilder)
+        case other =>
+          newLogger(newCoreLogger = core.withCondition(other.asJava))
+      }
     }
+
+    override def withFields(f: FB => FieldBuilderResult): AsyncLogger[FB] = {
+      newLogger(newCoreLogger = core.withFields[FB](f.asJava, fieldBuilder))
+    }
+
+    override def withExecutor(executor: Executor): AsyncLogger[FB] = {
+      newLogger(newCoreLogger = core.withExecutor(executor))
+    }
+
+    override def withThreadContext: AsyncLogger[FB] = newLogger(
+      newCoreLogger = core.withThreadContext(Utilities.threadContext())
+    )
+
+    override def withFieldBuilder[T](newBuilder: T): AsyncLogger[T] =
+      newLogger(newFieldBuilder = newBuilder)
+
+    @inline
+    private def newLogger[T](
+        newCoreLogger: CoreLogger = core,
+        newFieldBuilder: T = fieldBuilder
+    ): AsyncLogger[T] =
+      AsyncLogger[T](newCoreLogger, newFieldBuilder)
+
   }
 
-  override def withFields(f: FB => FieldBuilderResult): AsyncLogger[FB] = {
-    newLogger(newCoreLogger = core.withFields[FB](f.asJava, fieldBuilder))
-  }
+  trait NoOp[FB] extends AsyncLogger[FB] {
+    override def ifTraceEnabled(consumer: Handle => Unit): Unit = {}
 
-  def withExecutor(executor: Executor): AsyncLogger[FB] = {
-    newLogger(newCoreLogger = core.withExecutor(executor))
-  }
+    override def ifTraceEnabled(condition: Condition)(consumer: Handle => Unit): Unit = {}
 
-  override def withThreadContext: AsyncLogger[FB] = newLogger(
-    newCoreLogger = core.withThreadContext(Utilities.threadContext())
-  )
+    override def trace(message: String): Unit = {}
 
-  override def withFieldBuilder[T](newBuilder: T): AsyncLogger[T] =
-    newLogger(newFieldBuilder = newBuilder)
+    override def trace(message: String, f: FB => FieldBuilderResult): Unit = {}
 
-  @inline
-  private def newLogger[T](
-      newCoreLogger: CoreLogger = core,
-      newFieldBuilder: T = fieldBuilder
-  ): AsyncLogger[T] =
-    new AsyncLogger[T](newCoreLogger, newFieldBuilder)
+    override def trace(message: String, e: Throwable): Unit = {}
 
-  class NeverAsyncLogger(core: CoreLogger, fieldBuilder: FB) extends AsyncLogger[FB](core, fieldBuilder) {
+    override def trace(condition: Condition, message: String): Unit = {}
 
-    override def ifTraceEnabled(consumer: Handle => Unit): Unit                                  = {}
-    override def ifTraceEnabled(condition: Condition)(consumer: Handle => Unit): Unit            = {}
-    override def trace(message: String): Unit                                                    = {}
-    override def trace(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def trace(message: String, e: Throwable): Unit                                      = {}
-    override def trace(condition: Condition, message: String): Unit                              = {}
     override def trace(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
-    override def trace(condition: Condition, message: String, e: Throwable): Unit                = {}
 
-    override def ifDebugEnabled(consumer: Handle => Unit): Unit                                  = {}
-    override def ifDebugEnabled(condition: Condition)(consumer: Handle => Unit): Unit            = {}
-    override def debug(message: String): Unit                                                    = {}
-    override def debug(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def debug(message: String, e: Throwable): Unit                                      = {}
-    override def debug(condition: Condition, message: String): Unit                              = {}
+    override def trace(condition: Condition, message: String, e: Throwable): Unit = {}
+
+    override def ifDebugEnabled(consumer: Handle => Unit): Unit = {}
+
+    override def ifDebugEnabled(condition: Condition)(consumer: Handle => Unit): Unit = {}
+
+    override def debug(message: String): Unit = {}
+
+    override def debug(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def debug(message: String, e: Throwable): Unit = {}
+
+    override def debug(condition: Condition, message: String): Unit = {}
+
     override def debug(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
-    override def debug(condition: Condition, message: String, e: Throwable): Unit                = {}
 
-    override def ifInfoEnabled(consumer: Handle => Unit): Unit                                  = {}
-    override def ifInfoEnabled(condition: Condition)(consumer: Handle => Unit): Unit            = {}
-    override def info(message: String): Unit                                                    = {}
-    override def info(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def info(message: String, e: Throwable): Unit                                      = {}
-    override def info(condition: Condition, message: String): Unit                              = {}
+    override def debug(condition: Condition, message: String, e: Throwable): Unit = {}
+
+    override def ifInfoEnabled(consumer: Handle => Unit): Unit = {}
+
+    override def ifInfoEnabled(condition: Condition)(consumer: Handle => Unit): Unit = {}
+
+    override def info(message: String): Unit = {}
+
+    override def info(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def info(message: String, e: Throwable): Unit = {}
+
+    override def info(condition: Condition, message: String): Unit = {}
+
     override def info(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
-    override def info(condition: Condition, message: String, e: Throwable): Unit                = {}
 
-    override def ifWarnEnabled(consumer: Handle => Unit): Unit                                  = {}
-    override def ifWarnEnabled(condition: Condition)(consumer: Handle => Unit): Unit            = {}
-    override def warn(message: String): Unit                                                    = {}
-    override def warn(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def warn(message: String, e: Throwable): Unit                                      = {}
-    override def warn(condition: Condition, message: String): Unit                              = {}
+    override def info(condition: Condition, message: String, e: Throwable): Unit = {}
+
+    override def ifWarnEnabled(consumer: Handle => Unit): Unit = {}
+
+    override def ifWarnEnabled(condition: Condition)(consumer: Handle => Unit): Unit = {}
+
+    override def warn(message: String): Unit = {}
+
+    override def warn(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def warn(message: String, e: Throwable): Unit = {}
+
+    override def warn(condition: Condition, message: String): Unit = {}
+
     override def warn(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
-    override def warn(condition: Condition, message: String, e: Throwable): Unit                = {}
 
-    override def ifErrorEnabled(consumer: Handle => Unit): Unit                                  = {}
-    override def ifErrorEnabled(condition: Condition)(consumer: Handle => Unit): Unit            = {}
-    override def error(message: String): Unit                                                    = {}
-    override def error(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def error(message: String, e: Throwable): Unit                                      = {}
-    override def error(condition: Condition, message: String): Unit                              = {}
+    override def warn(condition: Condition, message: String, e: Throwable): Unit = {}
+
+    override def ifErrorEnabled(consumer: Handle => Unit): Unit = {}
+
+    override def ifErrorEnabled(condition: Condition)(consumer: Handle => Unit): Unit = {}
+
+    override def error(message: String): Unit = {}
+
+    override def error(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def error(message: String, e: Throwable): Unit = {}
+
+    override def error(condition: Condition, message: String): Unit = {}
+
     override def error(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
-    override def error(condition: Condition, message: String, e: Throwable): Unit                = {}
+
+    override def error(condition: Condition, message: String, e: Throwable): Unit = {}
+  }
+
+  object NoOp {
+
+    def apply[FB](c: CoreLogger, fb: FB): AsyncLogger[FB] = new NoOp[FB] {
+      override def name: String = c.getName
+
+      override def core: CoreLogger = c
+
+      override def fieldBuilder: FB = fb
+
+      override def withCondition(scalaCondition: Condition): AsyncLogger[FB] = this
+
+      override def withFields(f: FB => FieldBuilderResult): AsyncLogger[FB] = this
+
+      override def withThreadContext: AsyncLogger[FB] = this
+
+      override def withFieldBuilder[T <: FB](newBuilder: T): AsyncLogger[T] = NoOp(c, newBuilder)
+
+      override def withExecutor(executor: Executor): AsyncLogger[FB] = this
+    }
   }
 }

--- a/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLoggerFactory.scala
+++ b/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLoggerFactory.scala
@@ -13,17 +13,17 @@ object AsyncLoggerFactory {
 
   def getLogger(name: String): AsyncLogger[FieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
-    new AsyncLogger(core, fieldBuilder)
+    AsyncLogger(core, fieldBuilder)
   }
 
   def getLogger(clazz: Class[_]): AsyncLogger[FieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
-    new AsyncLogger(core, fieldBuilder)
+    AsyncLogger(core, fieldBuilder)
   }
 
   def getLogger: AsyncLogger[FieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
-    new AsyncLogger(core, fieldBuilder)
+    AsyncLogger(core, fieldBuilder)
   }
 
 }

--- a/diff/src/main/scala/com/tersesystems/echopraxia/plusscala/diff/DiffFieldBuilder.scala
+++ b/diff/src/main/scala/com/tersesystems/echopraxia/plusscala/diff/DiffFieldBuilder.scala
@@ -6,8 +6,7 @@ import com.tersesystems.echopraxia.api.{Field, Value}
 import com.tersesystems.echopraxia.plusscala.api.ValueTypeClasses
 
 /**
- * This field builder uses the stable structured representation of objects to diff
- * them against each other.
+ * This field builder uses the stable structured representation of objects to diff them against each other.
  *
  * It depends on Jackson and zjsonpatch internally.
  */
@@ -17,17 +16,22 @@ trait DiffFieldBuilder extends ValueTypeClasses {
   /**
    * Diff two values against each other.
    *
-   * @param fieldName the field name to give the diff
-   * @param before object before (aka `base`)
-   * @param after object after (aka `working`)
-   * @tparam T the type of the object
-   * @return the field representing the diff between the two values.
+   * @param fieldName
+   *   the field name to give the diff
+   * @param before
+   *   object before (aka `base`)
+   * @param after
+   *   object after (aka `working`)
+   * @tparam T
+   *   the type of the object
+   * @return
+   *   the field representing the diff between the two values.
    */
   def diff[T: ToValue](fieldName: String, before: T, after: T): Field = {
     // XXX should add this to Java version and then map it through
     val beforeNode: JsonNode = mapper.valueToTree(ToValue(before))
-    val afterNode: JsonNode = mapper.valueToTree(ToValue(after))
-    val patch: JsonNode = JsonDiff.asJson(beforeNode, afterNode)
+    val afterNode: JsonNode  = mapper.valueToTree(ToValue(after))
+    val patch: JsonNode      = JsonDiff.asJson(beforeNode, afterNode)
     // convert the patch json node back to fields and values :-)
     val value: Value[_] = mapper.convertValue(patch, classOf[Value[_]])
     Field.keyValue(fieldName, value)

--- a/diff/src/test/scala/com/tersesystems/echopraxia/plusscala/diff/DiffFieldBuilderSpec.scala
+++ b/diff/src/test/scala/com/tersesystems/echopraxia/plusscala/diff/DiffFieldBuilderSpec.scala
@@ -17,8 +17,8 @@ class DiffBuilderSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
   describe("logging") {
 
     it("should diff correctly") {
-      val person1 = Person("person1", 13)
-      val person2 = Person("person2", 13)
+      val person1   = Person("person1", 13)
+      val person2   = Person("person2", 13)
       val diffField = fb.diff("personDiff", person1, person2)
 
       val obj = diffField.value.asInstanceOf[Value.ArrayValue]
@@ -60,7 +60,6 @@ class DiffBuilderSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 }
 
 case class Person(name: String, age: Int)
-
 
 case class User(name: String, id: Int)
 

--- a/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLogger.scala
+++ b/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLogger.scala
@@ -5,49 +5,71 @@ import com.tersesystems.echopraxia.plusscala.api._
 
 import scala.compat.java8.FunctionConverters._
 
-class FlowLogger[FB <: FlowFieldBuilder](core: CoreLogger, fieldBuilder: FB)
-    extends AbstractLoggerSupport(core, fieldBuilder)
-    with DefaultFlowLoggerMethods[FB]
-    with LoggerSupport[FB] {
+trait FlowLogger[FB <: FlowFieldBuilder] extends FlowLoggerMethods[FB] with LoggerSupport[FB, FlowLogger] with DefaultMethodsSupport[FB]
 
-  override def withCondition(condition: Condition): FlowLogger[FB] = {
-    condition match {
-      case Condition.never =>
-        neverLogger()
-      case other =>
-        newLogger(newCoreLogger = core.withCondition(other.asJava))
+object FlowLogger {
+
+  def apply[FB <: FlowFieldBuilder](c: CoreLogger, fb: FB): FlowLogger[FB] = new Impl(c, fb)
+
+  class Impl[FB <: FlowFieldBuilder](val core: CoreLogger, val fieldBuilder: FB) extends FlowLogger[FB] with DefaultFlowLoggerMethods[FB] {
+
+    override def name: String = core.getName
+
+    override def withCondition(condition: Condition): FlowLogger[FB] = {
+      condition match {
+        case Condition.never =>
+          neverLogger()
+        case other =>
+          newLogger(newCoreLogger = core.withCondition(other.asJava))
+      }
+    }
+
+    override def withFields(f: FB => FieldBuilderResult): FlowLogger[FB] = {
+      newLogger(newCoreLogger = core.withFields(f.asJava, fieldBuilder))
+    }
+
+    override def withThreadContext: FlowLogger[FB] = {
+      newLogger(
+        newCoreLogger = core.withThreadContext(Utilities.threadContext())
+      )
+    }
+
+    def withFieldBuilder[NEWFB <: FlowFieldBuilder](newFieldBuilder: NEWFB): FlowLogger[NEWFB] = {
+      newLogger(newFieldBuilder = newFieldBuilder)
+    }
+
+    @inline
+    private def neverLogger(): FlowLogger[FB] = {
+      NoOp[FB](core.withCondition(Condition.never.asJava), fieldBuilder)
+    }
+
+    @inline
+    private def newLogger[T <: FlowFieldBuilder](
+        newCoreLogger: CoreLogger = core,
+        newFieldBuilder: T = fieldBuilder
+    ): FlowLogger[T] =
+      FlowLogger[T](newCoreLogger, newFieldBuilder)
+  }
+
+  object NoOp {
+    def apply[FB <: FlowFieldBuilder](c: CoreLogger, fb: FB): FlowLogger[FB] = new NoOp[FB] {
+      override def name: String = c.getName
+
+      override def core: CoreLogger = c
+
+      override def fieldBuilder: FB = fb
+
+      override def withCondition(scalaCondition: Condition): FlowLogger[FB] = this
+
+      override def withFields(f: FB => FieldBuilderResult): FlowLogger[FB] = this
+
+      override def withThreadContext: FlowLogger[FB] = this
+
+      override def withFieldBuilder[T <: FB](newBuilder: T): FlowLogger[T] = NoOp(c, newBuilder)
     }
   }
 
-  override def withFields(f: FB => FieldBuilderResult): FlowLogger[FB] = {
-    newLogger(newCoreLogger = core.withFields(f.asJava, fieldBuilder))
-  }
-
-  override def withThreadContext: FlowLogger[FB] = {
-    newLogger(
-      newCoreLogger = core.withThreadContext(Utilities.threadContext())
-    )
-  }
-
-  def withFieldBuilder[NEWFB <: FlowFieldBuilder](newFieldBuilder: NEWFB): FlowLogger[NEWFB] = {
-    newLogger(newFieldBuilder = newFieldBuilder)
-  }
-
-  @inline
-  private def neverLogger(): FlowLogger[FB] = {
-    new FlowLogger.NeverLogger[FB](core.withCondition(Condition.never.asJava), fieldBuilder)
-  }
-
-  @inline
-  private def newLogger[T <: FlowFieldBuilder](
-      newCoreLogger: CoreLogger = core,
-      newFieldBuilder: T = fieldBuilder
-  ): FlowLogger[T] =
-    new FlowLogger[T](newCoreLogger, newFieldBuilder)
-}
-
-object FlowLogger {
-  final class NeverLogger[FB <: FlowFieldBuilder](core: CoreLogger, fieldBuilder: FB) extends FlowLogger[FB](core, fieldBuilder) {
+  trait NoOp[FB <: FlowFieldBuilder] extends FlowLogger[FB] {
     override def trace[B: ToValue](attempt: => B): B                       = attempt
     override def trace[B: ToValue](condition: Condition)(attempt: => B): B = attempt
     override def debug[B: ToValue](attempt: => B): B                       = attempt

--- a/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLoggerFactory.scala
+++ b/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLoggerFactory.scala
@@ -9,17 +9,17 @@ object FlowLoggerFactory {
 
   def getLogger(name: String): FlowLogger[FlowFieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
-    new FlowLogger(core, fieldBuilder)
+    FlowLogger(core, fieldBuilder)
   }
 
   def getLogger(clazz: Class[_]): FlowLogger[FlowFieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
-    new FlowLogger(core, fieldBuilder)
+    FlowLogger(core, fieldBuilder)
   }
 
   def getLogger: FlowLogger[FlowFieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
-    new FlowLogger(core, fieldBuilder)
+    FlowLogger(core, fieldBuilder)
   }
 
 }

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
@@ -1,95 +1,153 @@
 package com.tersesystems.echopraxia.plusscala
 
 import com.tersesystems.echopraxia.api.{CoreLogger, FieldBuilderResult, Utilities}
-import com.tersesystems.echopraxia.plusscala.api.{AbstractLoggerSupport, Condition, LoggerSupport}
+import com.tersesystems.echopraxia.plusscala.api.{Condition, DefaultMethodsSupport, LoggerSupport}
 
 import scala.compat.java8.FunctionConverters.enrichAsJavaFunction
 
-/**
- */
-class Logger[FB](core: CoreLogger, fieldBuilder: FB)
-    extends AbstractLoggerSupport(core, fieldBuilder)
-    with LoggerSupport[FB]
-    with DefaultLoggerMethods[FB] {
+trait Logger[FB] extends LoggerMethods[FB] with LoggerSupport[FB, Logger] with DefaultMethodsSupport[FB]
 
-  override def name: String = core.getName
+object Logger {
 
-  override def withCondition(condition: Condition): Logger[FB] = {
-    condition match {
-      case Condition.always =>
-        this
-      case Condition.never =>
-        new NeverLogger(core, fieldBuilder)
-      case other =>
-        newLogger(newCoreLogger = core.withCondition(other.asJava))
+  def apply[FB](core: CoreLogger, fieldBuilder: FB): Logger[FB] = new Impl[FB](core, fieldBuilder)
+
+  /**
+   */
+  class Impl[FB](val core: CoreLogger, val fieldBuilder: FB) extends Logger[FB] with DefaultLoggerMethods[FB] {
+
+    override def name: String = core.getName
+
+    override def withCondition(condition: Condition): Logger[FB] = {
+      condition match {
+        case Condition.always =>
+          this
+        case Condition.never =>
+          NoOp(core, fieldBuilder)
+        case other =>
+          newLogger(newCoreLogger = core.withCondition(other.asJava))
+      }
     }
+
+    override def withFields(f: FB => FieldBuilderResult): Logger[FB] = {
+      newLogger(newCoreLogger = core.withFields(f.asJava, fieldBuilder))
+    }
+
+    override def withThreadContext: Logger[FB] = {
+      newLogger(
+        newCoreLogger = core.withThreadContext(Utilities.threadContext())
+      )
+    }
+
+    override def withFieldBuilder[NEWFB](newFieldBuilder: NEWFB): Logger[NEWFB] = {
+      newLogger(newFieldBuilder = newFieldBuilder)
+    }
+
+    @inline
+    private def newLogger[T](
+        newCoreLogger: CoreLogger = core,
+        newFieldBuilder: T = fieldBuilder
+    ): Logger[T] =
+      new Impl[T](newCoreLogger, newFieldBuilder)
+
   }
 
-  override def withFields(f: FB => FieldBuilderResult): Logger[FB] = {
-    newLogger(newCoreLogger = core.withFields(f.asJava, fieldBuilder))
-  }
+  trait NoOp[FB] extends Logger[FB] {
+    override def isTraceEnabled: Boolean = false
 
-  override def withThreadContext: Logger[FB] = {
-    newLogger(
-      newCoreLogger = core.withThreadContext(Utilities.threadContext())
-    )
-  }
+    override def isTraceEnabled(condition: Condition): Boolean = false
 
-  override def withFieldBuilder[NEWFB](newFieldBuilder: NEWFB): Logger[NEWFB] = {
-    newLogger(newFieldBuilder = newFieldBuilder)
-  }
+    override def trace(message: String): Unit = {}
 
-  @inline
-  private def newLogger[T](
-      newCoreLogger: CoreLogger = core,
-      newFieldBuilder: T = fieldBuilder
-  ): Logger[T] =
-    new Logger[T](newCoreLogger, newFieldBuilder)
+    override def trace(message: String, e: Throwable): Unit = {}
 
-  class NeverLogger(core: CoreLogger, fieldBuilder: FB) extends Logger[FB](core: CoreLogger, fieldBuilder: FB) {
-    override def isTraceEnabled: Boolean                                                         = false
-    override def isTraceEnabled(condition: Condition): Boolean                                   = false
-    override def trace(message: String): Unit                                                    = {}
-    override def trace(message: String, e: Throwable): Unit                                      = {}
-    override def trace(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def trace(condition: Condition, message: String): Unit                              = {}
-    override def trace(condition: Condition, message: String, e: Throwable): Unit                = {}
+    override def trace(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def trace(condition: Condition, message: String): Unit = {}
+
+    override def trace(condition: Condition, message: String, e: Throwable): Unit = {}
+
     override def trace(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isDebugEnabled: Boolean                                                         = false
-    override def isDebugEnabled(condition: Condition): Boolean                                   = false
-    override def debug(message: String): Unit                                                    = {}
-    override def debug(message: String, e: Throwable): Unit                                      = {}
-    override def debug(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def debug(condition: Condition, message: String): Unit                              = {}
-    override def debug(condition: Condition, message: String, e: Throwable): Unit                = {}
+    override def isDebugEnabled: Boolean = false
+
+    override def isDebugEnabled(condition: Condition): Boolean = false
+
+    override def debug(message: String): Unit = {}
+
+    override def debug(message: String, e: Throwable): Unit = {}
+
+    override def debug(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def debug(condition: Condition, message: String): Unit = {}
+
+    override def debug(condition: Condition, message: String, e: Throwable): Unit = {}
+
     override def debug(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isInfoEnabled: Boolean                                                         = false
-    override def isInfoEnabled(condition: Condition): Boolean                                   = false
-    override def info(message: String): Unit                                                    = {}
-    override def info(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def info(message: String, e: Throwable): Unit                                      = {}
-    override def info(condition: Condition, message: String): Unit                              = {}
-    override def info(condition: Condition, message: String, e: Throwable): Unit                = {}
+    override def isInfoEnabled: Boolean = false
+
+    override def isInfoEnabled(condition: Condition): Boolean = false
+
+    override def info(message: String): Unit = {}
+
+    override def info(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def info(message: String, e: Throwable): Unit = {}
+
+    override def info(condition: Condition, message: String): Unit = {}
+
+    override def info(condition: Condition, message: String, e: Throwable): Unit = {}
+
     override def info(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isWarnEnabled: Boolean                                                         = false
-    override def isWarnEnabled(condition: Condition): Boolean                                   = false
-    override def warn(message: String): Unit                                                    = {}
-    override def warn(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def warn(message: String, e: Throwable): Unit                                      = {}
-    override def warn(condition: Condition, message: String): Unit                              = {}
-    override def warn(condition: Condition, message: String, e: Throwable): Unit                = {}
+    override def isWarnEnabled: Boolean = false
+
+    override def isWarnEnabled(condition: Condition): Boolean = false
+
+    override def warn(message: String): Unit = {}
+
+    override def warn(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def warn(message: String, e: Throwable): Unit = {}
+
+    override def warn(condition: Condition, message: String): Unit = {}
+
+    override def warn(condition: Condition, message: String, e: Throwable): Unit = {}
+
     override def warn(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
 
-    override def isErrorEnabled: Boolean                                                         = false
-    override def isErrorEnabled(condition: Condition): Boolean                                   = false
-    override def error(message: String): Unit                                                    = {}
-    override def error(message: String, f: FB => FieldBuilderResult): Unit                       = {}
-    override def error(message: String, e: Throwable): Unit                                      = {}
-    override def error(condition: Condition, message: String): Unit                              = {}
-    override def error(condition: Condition, message: String, e: Throwable): Unit                = {}
+    override def isErrorEnabled: Boolean = false
+
+    override def isErrorEnabled(condition: Condition): Boolean = false
+
+    override def error(message: String): Unit = {}
+
+    override def error(message: String, f: FB => FieldBuilderResult): Unit = {}
+
+    override def error(message: String, e: Throwable): Unit = {}
+
+    override def error(condition: Condition, message: String): Unit = {}
+
+    override def error(condition: Condition, message: String, e: Throwable): Unit = {}
+
     override def error(condition: Condition, message: String, f: FB => FieldBuilderResult): Unit = {}
+  }
+
+  object NoOp {
+    def apply[FB](c: CoreLogger, fb: FB): NoOp[FB] = new NoOp[FB] {
+      override def name: String = c.getName
+
+      override def core: CoreLogger = c
+
+      override def fieldBuilder: FB = fb
+
+      override def withCondition(scalaCondition: Condition): Logger[FB] = this
+
+      override def withFields(f: FB => FieldBuilderResult): Logger[FB] = this
+
+      override def withThreadContext: Logger[FB] = this
+
+      override def withFieldBuilder[T <: FB](newBuilder: T): Logger[T] = NoOp(core, newBuilder)
+    }
   }
 }

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/LoggerFactory.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/LoggerFactory.scala
@@ -13,17 +13,17 @@ object LoggerFactory {
 
   def getLogger(name: String): Logger[FieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
-    new Logger(core, fieldBuilder)
+    Logger(core, fieldBuilder)
   }
 
   def getLogger(clazz: Class[_]): Logger[FieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
-    new Logger(core, fieldBuilder)
+    Logger(core, fieldBuilder)
   }
 
   def getLogger: Logger[FieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
-    new Logger(core, fieldBuilder)
+    Logger(core, fieldBuilder)
   }
 
 }

--- a/logger/src/test/scala/com/tersesystems/echopraxia/plusscala/ConditionSpec.scala
+++ b/logger/src/test/scala/com/tersesystems/echopraxia/plusscala/ConditionSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 
 import java.util
+import scala.annotation.nowarn
 
 class ConditionSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 

--- a/logger/src/test/scala/com/tersesystems/echopraxia/plusscala/Main.scala
+++ b/logger/src/test/scala/com/tersesystems/echopraxia/plusscala/Main.scala
@@ -11,7 +11,13 @@ object Main {
 
   case class Book(category: String, author: String, title: String, price: Double)
 
+  case class CreditCard(number: String, expirationDate: String)
+
   def main(args: Array[String]): Unit = {
+
+    implicit val sensitive = Explicit
+    val creditCard         = CreditCard("4111 1111 1111 1111", "04/23")
+    logger.info("{}", _.keyValue("creditCard", creditCard))
 
     val refBook = Book("reference", "Nigel Rees", "Sayings of the Century", 8.95)
     logger.info(
@@ -24,13 +30,20 @@ object Main {
 
     logger.info("{}", _.keyValue("thisbook" -> refBook))
 
-    logger.info("testing {} {}", fb => (
-      //fb.keyValue("foo", fb.book(refBook)),
-      fb.keyValue("foo", refBook),
-      // https://stackoverflow.com/questions/5598085/where-does-scala-look-for-implicits/5598107#5598107
-      //fb.keyValue("foo" -> refBook),
-      //fb.keyValue("foo", refBook),
-    ))
+    logger.info(
+      "testing {} {}",
+      fb =>
+        (
+          // fb.keyValue("foo", fb.book(refBook)),
+          fb.keyValue(
+            "foo",
+            refBook
+          )
+          // https://stackoverflow.com/questions/5598085/where-does-scala-look-for-implicits/5598107#5598107
+          // fb.keyValue("foo" -> refBook),
+          // fb.keyValue("foo", refBook),
+        )
+    )
     logger.info("{}", _.keyValue("instant", Instant.now()))
 
     logger.info("array of throwables {}", fb => fb.array("ex" -> Seq(new RuntimeException())))
@@ -44,7 +57,32 @@ object Main {
 
   val infoAndFoo: Condition = infoOrHigherCondition xor fooCondition
 
-  trait MyFieldBuilder extends FieldBuilder {
+  sealed trait Sensitive
+
+  case object Censored extends Sensitive
+
+  case object Explicit extends Sensitive
+
+  trait CreditCardFieldBuilder extends FieldBuilder {
+
+    implicit def creditCardToValue(implicit cap: Sensitive = Censored): ToValue[CreditCard] = cc => {
+      ToObjectValue(
+        sensitiveKeyValue("number", cc.number),
+        keyValue("expirationDate", cc.expirationDate)
+      )
+    }
+
+    def sensitiveKeyValue(name: String, value: String)(implicit cap: Sensitive = Censored): Field = {
+      cap match {
+        case Censored =>
+          keyValue(name, "[CENSORED]")
+        case Explicit =>
+          keyValue(name, value)
+      }
+    }
+  }
+
+  trait MyFieldBuilder extends CreditCardFieldBuilder with FieldBuilder {
     implicit val instantToStringValue: ToValue[Instant] = (t: Instant) => ToValue(t.toString)
 
     def instant(name: String, i: Instant): Field = keyValue(name, ToValue(i))

--- a/nameof/src/main/scala/com/tersesystems/echopraxia/plusscala/nameof/NameOfFieldBuilder.scala
+++ b/nameof/src/main/scala/com/tersesystems/echopraxia/plusscala/nameof/NameOfFieldBuilder.scala
@@ -18,18 +18,18 @@ trait NameOfFieldBuilder extends FieldBuilder {
 }
 
 object NameOfFieldBuilder extends NameOfFieldBuilder {
-  
+
   private class impl(val c: blackbox.Context) {
     import c.universe._
 
     def nameOf(expr: c.Expr[Any]): c.Expr[String] = {
       import c.universe._
       @tailrec def extract(tree: c.Tree): String = tree match {
-        case Ident(n) => n.decodedName.toString
-        case Select(_, n) => n.decodedName.toString
-        case Function(_, body) => extract(body)
-        case Block(_, expr) => extract(expr)
-        case Apply(func, _) => extract(func)
+        case Ident(n)           => n.decodedName.toString
+        case Select(_, n)       => n.decodedName.toString
+        case Function(_, body)  => extract(body)
+        case Block(_, expr)     => extract(expr)
+        case Apply(func, _)     => extract(func)
         case TypeApply(func, _) => extract(func)
         case _ =>
           c.abort(c.enclosingPosition, s"Unsupported expression: ${expr.tree}")
@@ -43,41 +43,41 @@ object NameOfFieldBuilder extends NameOfFieldBuilder {
       val tpeA: Type = implicitly[WeakTypeTag[A]].tpe
       // taken from https://github.com/dwickern/scala-nameof
       @tailrec def extract(tree: c.Tree): String = tree match {
-        case Ident(n) => n.decodedName.toString
-        case Select(_, n) => n.decodedName.toString
-        case Function(_, body) => extract(body)
-        case Block(_, expr) => extract(expr)
-        case Apply(func, _) => extract(func)
+        case Ident(n)           => n.decodedName.toString
+        case Select(_, n)       => n.decodedName.toString
+        case Function(_, body)  => extract(body)
+        case Block(_, expr)     => extract(expr)
+        case Apply(func, _)     => extract(func)
         case TypeApply(func, _) => extract(func)
         case _ =>
           c.abort(c.enclosingPosition, s"Unsupported expression: ${expr}")
       }
       val name = expr match {
         case Literal(Constant(_)) => c.abort(c.enclosingPosition, "Cannot provide name to static constant!")
-        case _ => extract(expr)
+        case _                    => extract(expr)
       }
-            
+
       q"""(${c.prefix}.keyValue($name, fb.ToValue[$tpeA]($expr)))"""
     }
 
     def value[A: c.WeakTypeTag](expr: c.Tree): c.Tree = {
       val tpeA: Type = implicitly[WeakTypeTag[A]].tpe
-            // taken from https://github.com/dwickern/scala-nameof
+      // taken from https://github.com/dwickern/scala-nameof
       @tailrec def extract(tree: c.Tree): String = tree match {
-        case Ident(n) => n.decodedName.toString
-        case Select(_, n) => n.decodedName.toString
-        case Function(_, body) => extract(body)
-        case Block(_, expr) => extract(expr)
-        case Apply(func, _) => extract(func)
+        case Ident(n)           => n.decodedName.toString
+        case Select(_, n)       => n.decodedName.toString
+        case Function(_, body)  => extract(body)
+        case Block(_, expr)     => extract(expr)
+        case Apply(func, _)     => extract(func)
         case TypeApply(func, _) => extract(func)
         case _ =>
           c.abort(c.enclosingPosition, s"Unsupported expression: ${expr}")
       }
       val name = expr match {
         case Literal(Constant(_)) => c.abort(c.enclosingPosition, "Cannot provide name to static constant!")
-        case _ => extract(expr)
+        case _                    => extract(expr)
       }
-            
+
       q"""(${c.prefix}.value($name, fb.ToValue[$tpeA]($expr)))"""
     }
   }

--- a/nameof/src/test/scala/com/tersesystems/echopraxia/plusscala/nameof/NameOfFieldBuilderSpec.scala
+++ b/nameof/src/test/scala/com/tersesystems/echopraxia/plusscala/nameof/NameOfFieldBuilderSpec.scala
@@ -1,6 +1,5 @@
 package com.tersesystems.echopraxia.plusscala.nameof
 
-
 import com.tersesystems.echopraxia.api.Field
 import com.tersesystems.echopraxia.plusscala.api._
 import org.scalatest.BeforeAndAfterEach
@@ -10,25 +9,25 @@ import org.scalatest.matchers.must.Matchers
 import java.time.Instant
 
 class NameOfFieldBuilderSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
-  
+
   private val fb = MyFieldBuilder
 
   describe("logging") {
 
     it("should log a person as keyValue") {
       val person = Person("thisperson", 13)
-      val field = fb.nameOfKeyValue(person)
+      val field  = fb.nameOfKeyValue(person)
 
-      field.name() must be("person")      
+      field.name() must be("person")
     }
 
     it("should log a person as value") {
       val person = Person("thisperson", 13)
-      val field = fb.nameOfValue(person)
+      val field  = fb.nameOfValue(person)
 
-      field.name() must be("person")      
+      field.name() must be("person")
     }
-    
+
   }
 
   trait MyFieldBuilder extends NameOfFieldBuilder with FieldBuilder {

--- a/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceLogger.scala
+++ b/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceLogger.scala
@@ -6,58 +6,89 @@ import sourcecode.{Args, Enclosing, File, Line}
 
 import scala.compat.java8.FunctionConverters._
 
-class TraceLogger[FB <: TraceFieldBuilder](core: CoreLogger, fieldBuilder: FB)
-    extends AbstractLoggerSupport(core, fieldBuilder)
-    with DefaultTraceLoggerMethods[FB]
-    with LoggerSupport[FB] {
-
-  override def withCondition(condition: Condition): TraceLogger[FB] = {
-    condition match {
-      case Condition.never =>
-        neverLogger()
-      case other =>
-        newLogger(newCoreLogger = core.withCondition(other.asJava))
-    }
-  }
-
-  override def withFields(f: FB => FieldBuilderResult): TraceLogger[FB] = {
-    newLogger(newCoreLogger = core.withFields(f.asJava, fieldBuilder))
-  }
-
-  override def withThreadContext: TraceLogger[FB] = {
-    newLogger(
-      newCoreLogger = core.withThreadContext(Utilities.threadContext())
-    )
-  }
-
-  override def withFieldBuilder[NEWFB <: TraceFieldBuilder](newFieldBuilder: NEWFB): TraceLogger[NEWFB] = {
-    newLogger(newFieldBuilder = newFieldBuilder)
-  }
-
-  @inline
-  private def neverLogger(): TraceLogger[FB] = {
-    new TraceLogger.Never[FB](core.withCondition(Condition.never.asJava), fieldBuilder)
-  }
-
-  @inline
-  private def newLogger[T <: TraceFieldBuilder](
-      newCoreLogger: CoreLogger = core,
-      newFieldBuilder: T = fieldBuilder
-  ): TraceLogger[T] =
-    new TraceLogger[T](newCoreLogger, newFieldBuilder)
-}
+trait TraceLogger[FB <: TraceFieldBuilder] extends LoggerSupport[FB, TraceLogger] with TraceLoggerMethods[FB] with DefaultMethodsSupport[FB]
 
 object TraceLogger {
-  final class Never[FB <: TraceFieldBuilder](core: CoreLogger, fieldBuilder: FB) extends TraceLogger[FB](core, fieldBuilder) {
-    override def trace[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                       = attempt
+
+  def apply[FB <: TraceFieldBuilder](core: CoreLogger, fieldBuilder: FB): TraceLogger[FB] = new Impl(core, fieldBuilder)
+
+  class Impl[FB <: TraceFieldBuilder](val core: CoreLogger, val fieldBuilder: FB) extends TraceLogger[FB] with DefaultTraceLoggerMethods[FB] {
+
+    override def name: String = core.getName
+
+    override def withCondition(condition: Condition): TraceLogger[FB] = {
+      condition match {
+        case Condition.never =>
+          neverLogger()
+        case other =>
+          newLogger(newCoreLogger = core.withCondition(other.asJava))
+      }
+    }
+
+    override def withFields(f: FB => FieldBuilderResult): TraceLogger[FB] = {
+      newLogger(newCoreLogger = core.withFields(f.asJava, fieldBuilder))
+    }
+
+    override def withThreadContext: TraceLogger[FB] = {
+      newLogger(
+        newCoreLogger = core.withThreadContext(Utilities.threadContext())
+      )
+    }
+
+    override def withFieldBuilder[NEWFB <: TraceFieldBuilder](newFieldBuilder: NEWFB): TraceLogger[NEWFB] = {
+      newLogger(newFieldBuilder = newFieldBuilder)
+    }
+
+    @inline
+    private def neverLogger(): TraceLogger[FB] = {
+      TraceLogger.NoOp[FB](core.withCondition(Condition.never.asJava), fieldBuilder)
+    }
+
+    @inline
+    private def newLogger[T <: TraceFieldBuilder](
+        newCoreLogger: CoreLogger = core,
+        newFieldBuilder: T = fieldBuilder
+    ): TraceLogger[T] = TraceLogger[T](newCoreLogger, newFieldBuilder)
+  }
+
+  trait NoOp[FB <: TraceFieldBuilder] extends TraceLogger[FB] {
+    override def trace[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
     override def trace[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def debug[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                       = attempt
+
+    override def debug[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
     override def debug[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
-    override def info[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                        = attempt
-    override def info[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B  = attempt
-    override def warn[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                        = attempt
-    override def warn[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B  = attempt
-    override def error[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B                       = attempt
+
+    override def info[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
+    override def info[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
+    override def warn[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
+    override def warn[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
+    override def error[B: ToValue](attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+
     override def error[B: ToValue](condition: Condition)(attempt: => B)(implicit line: Line, file: File, enc: Enclosing, args: Args): B = attempt
+  }
+
+  object NoOp {
+    def apply[FB <: TraceFieldBuilder](c: CoreLogger, fb: FB): TraceLogger[FB] = new NoOp[FB] {
+      override def name: String = c.getName
+
+      override def core: CoreLogger = c
+
+      override def fieldBuilder: FB = fb
+
+      override def withCondition(scalaCondition: Condition): TraceLogger[FB] = this
+
+      override def withFields(f: FB => FieldBuilderResult): TraceLogger[FB] = this
+
+      override def withThreadContext: TraceLogger[FB] = this
+
+      override def withFieldBuilder[T <: FB](newBuilder: T): TraceLogger[T] = NoOp(c, newBuilder)
+    }
+
   }
 }

--- a/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceLoggerFactory.scala
+++ b/trace/src/main/scala/com/tersesystems/echopraxia/plusscala/trace/TraceLoggerFactory.scala
@@ -9,17 +9,17 @@ object TraceLoggerFactory {
 
   def getLogger(name: String): TraceLogger[TraceFieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
-    new TraceLogger(core, fieldBuilder)
+    TraceLogger(core, fieldBuilder)
   }
 
   def getLogger(clazz: Class[_]): TraceLogger[TraceFieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
-    new TraceLogger(core, fieldBuilder)
+    TraceLogger(core, fieldBuilder)
   }
 
   def getLogger: TraceLogger[TraceFieldBuilder] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
-    new TraceLogger(core, fieldBuilder)
+    TraceLogger(core, fieldBuilder)
   }
 
 }


### PR DESCRIPTION
Do some internal refactoring to make `Logger`, `AsyncLogger`, `FlowLogger` and `TraceLogger` into traits, so it's much easier to create your own implementations.  Also removes `AbstractLoggingSupport`.