### PR TITLE
Add name type

### DIFF
--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
@@ -5,6 +5,10 @@ import com.tersesystems.echopraxia.api._
 
 import scala.annotation.implicitNotFound
 
+trait HasName {
+  type Name = String
+}
+
 trait ValueTypeClasses {
 
   /**
@@ -212,89 +216,89 @@ trait ListToFieldBuilderResultMethods extends FieldBuilderResultTypeClasses {
 
 }
 
-trait TupleFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMethods {
-  def keyValue[V: ToValue](tuple: (String, V)): Field = Field.keyValue(tuple._1, ToValue(tuple._2))
+trait TupleFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMethods with HasName {
+  def keyValue[V: ToValue](tuple: (Name, V)): Field = Field.keyValue(tuple._1, ToValue(tuple._2))
 
-  def value[V: ToValue](tuple: (String, V)): Field = Field.value(tuple._1, ToValue(tuple._2))
+  def value[V: ToValue](tuple: (Name, V)): Field = Field.value(tuple._1, ToValue(tuple._2))
 
-  def string(tuple: (String, String)): Field = value(tuple)
+  def string(tuple: (Name, String)): Field = value(tuple)
 
-  def number[N: ToValue: Numeric](tuple: (String, N)): Field = value(tuple)
+  def number[N: ToValue: Numeric](tuple: (Name, N)): Field = value(tuple)
 
-  def bool(tuple: (String, Boolean)): Field = value(tuple)
+  def bool(tuple: (Name, Boolean)): Field = value(tuple)
 
-  def exception(tuple: (String, Throwable)): Field = keyValue(tuple)
+  def exception(tuple: (Name, Throwable)): Field = keyValue(tuple)
 
-  def array[AV: ToArrayValue](tuple: (String, AV)): Field = keyValue(tuple)
+  def array[AV: ToArrayValue](tuple: (Name, AV)): Field = keyValue(tuple)
 
-  def obj[OV: ToObjectValue](tuple: (String, OV)): Field = keyValue(tuple)
+  def obj[OV: ToObjectValue](tuple: (Name, OV)): Field = keyValue(tuple)
 }
 
 /**
  * A field builder that is enhanced with ToValue, ToObjectValue, and ToArrayValue.
  */
-trait ArgsFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMethods {
+trait ArgsFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMethods with HasName {
 
   // ------------------------------------------------------------------
   // keyValue
 
-  def keyValue[V: ToValue](key: String, value: V): Field = Field.keyValue(key, ToValue(value))
+  def keyValue[V: ToValue](key: Name, value: V): Field = Field.keyValue(key, ToValue(value))
 
   // ------------------------------------------------------------------
   // value
 
-  def value[V: ToValue](key: String, value: V): Field = Field.value(key, ToValue(value))
+  def value[V: ToValue](key: Name, value: V): Field = Field.value(key, ToValue(value))
 
   // ------------------------------------------------------------------
   // string
 
-  def string(name: String, string: String): Field = value(name, string)
+  def string(name: Name, string: String): Field = value(name, string)
 
   // ------------------------------------------------------------------
   // number
 
-  def number(name: String, number: Byte): Field = value(name, number)
+  def number(name: Name, number: Byte): Field = value(name, number)
 
-  def number(name: String, number: Short): Field = value(name, number)
+  def number(name: Name, number: Short): Field = value(name, number)
 
-  def number(name: String, number: Int): Field = value(name, number)
+  def number(name: Name, number: Int): Field = value(name, number)
 
-  def number(name: String, number: Long): Field = value(name, number)
+  def number(name: Name, number: Long): Field = value(name, number)
 
-  def number(name: String, number: Float): Field = value(name, number)
+  def number(name: Name, number: Float): Field = value(name, number)
 
-  def number(name: String, number: Double): Field = value(name, number)
+  def number(name: Name, number: Double): Field = value(name, number)
 
-  def number(name: String, number: BigDecimal): Field = value(name, number)
+  def number(name: Name, number: BigDecimal): Field = value(name, number)
 
-  def number(name: String, number: BigInt): Field = value(name, number)
+  def number(name: Name, number: BigInt): Field = value(name, number)
 
   // ------------------------------------------------------------------
   // boolean
 
-  def bool(name: String, boolean: Boolean): Field = value(name, boolean)
+  def bool(name: Name, boolean: Boolean): Field = value(name, boolean)
 
   // ------------------------------------------------------------------
   // null
 
-  def nullField(name: String): Field = Field.keyValue(name, Value.nullValue())
+  def nullField(name: Name): Field = Field.keyValue(name, Value.nullValue())
 
   // ------------------------------------------------------------------
   // exception
 
   def exception(ex: Throwable): Field               = value(FieldConstants.EXCEPTION, ex)
-  def exception(name: String, ex: Throwable): Field = keyValue(name, ex)
+  def exception(name: Name, ex: Throwable): Field = keyValue(name, ex)
 
   // ------------------------------------------------------------------
   // array
 
-  def array[AV: ToArrayValue](name: String, value: AV): Field =
+  def array[AV: ToArrayValue](name: Name, value: AV): Field =
     keyValue(name, ToArrayValue[AV](value))
 
   // ------------------------------------------------------------------
   // object
 
-  def obj[OV: ToObjectValue](name: String, value: OV): Field =
+  def obj[OV: ToObjectValue](name: Name, value: OV): Field =
     keyValue(name, ToObjectValue[OV](value))
 
 }

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
@@ -6,7 +6,7 @@ import com.tersesystems.echopraxia.api._
 import scala.annotation.implicitNotFound
 
 trait HasName {
-  type Name = String
+  type Name
 }
 
 trait ValueTypeClasses {
@@ -217,9 +217,9 @@ trait ListToFieldBuilderResultMethods extends FieldBuilderResultTypeClasses {
 }
 
 trait TupleFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMethods with HasName {
-  def keyValue[V: ToValue](tuple: (Name, V)): Field = Field.keyValue(tuple._1, ToValue(tuple._2))
+  def keyValue[V: ToValue](tuple: (Name, V)): Field
 
-  def value[V: ToValue](tuple: (Name, V)): Field = Field.value(tuple._1, ToValue(tuple._2))
+  def value[V: ToValue](tuple: (Name, V)): Field
 
   def string(tuple: (Name, String)): Field = value(tuple)
 
@@ -242,12 +242,12 @@ trait ArgsFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMet
   // ------------------------------------------------------------------
   // keyValue
 
-  def keyValue[V: ToValue](key: Name, value: V): Field = Field.keyValue(key, ToValue(value))
+  def keyValue[V: ToValue](key: Name, value: V): Field
 
   // ------------------------------------------------------------------
   // value
 
-  def value[V: ToValue](key: Name, value: V): Field = Field.value(key, ToValue(value))
+  def value[V: ToValue](key: Name, value: V): Field
 
   // ------------------------------------------------------------------
   // string
@@ -281,12 +281,13 @@ trait ArgsFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMet
   // ------------------------------------------------------------------
   // null
 
-  def nullField(name: Name): Field = Field.keyValue(name, Value.nullValue())
+  def nullField(name: Name): Field = keyValue(name, Value.nullValue())
 
   // ------------------------------------------------------------------
   // exception
 
-  def exception(ex: Throwable): Field               = value(FieldConstants.EXCEPTION, ex)
+  def exception(ex: Throwable): Field = Field.value(FieldConstants.EXCEPTION, Value.exception(ex))
+
   def exception(name: Name, ex: Throwable): Field = keyValue(name, ex)
 
   // ------------------------------------------------------------------
@@ -303,6 +304,22 @@ trait ArgsFieldBuilder extends ValueTypeClasses with ListToFieldBuilderResultMet
 
 }
 
-trait FieldBuilder extends TupleFieldBuilder with ArgsFieldBuilder
+trait StringArgsFieldBuilder extends ArgsFieldBuilder with HasName {
+  override type Name = String
+
+  override def keyValue[V: ToValue](key: Name, value: V): Field = Field.keyValue(key, ToValue(value))
+
+  override def value[V: ToValue](key: Name, value: V): Field = Field.value(key, ToValue(value))
+}
+
+trait StringNameTupleFieldBuilder extends TupleFieldBuilder {
+  override type Name = String
+
+  override def keyValue[V: ToValue](tuple: (Name, V)): Field = Field.keyValue(tuple._1, ToValue(tuple._2))
+
+  override def value[V: ToValue](tuple: (Name, V)): Field = Field.value(tuple._1, ToValue(tuple._2))
+}
+
+trait FieldBuilder extends StringArgsFieldBuilder with StringNameTupleFieldBuilder
 
 object FieldBuilder extends FieldBuilder

--- a/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/RefinedFieldBuilderSpec.scala
+++ b/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/RefinedFieldBuilderSpec.scala
@@ -1,0 +1,39 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api.Field
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
+import eu.timepit.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.predicates.all.NonEmpty
+
+class RefinedFieldBuilderSpec extends AnyFunSpec with Matchers {
+
+  private val fb = RefinedFieldBuilder
+
+  describe("FieldBuilder") {
+
+    it("should work with java.lang.Byte") {
+      val byte = java.lang.Byte.MIN_VALUE
+      fb.keyValue(refineMV[NonEmpty]("byte"), byte)
+    }
+
+    it("should work with java.lang.Short") {
+      val short = java.lang.Short.MIN_VALUE
+      fb.keyValue(refineMV[NonEmpty]("short"), short)
+    }
+  }
+
+  trait RefinedFieldBuilder extends ArgsFieldBuilder with TupleFieldBuilder {
+    override type Name = String Refined NonEmpty
+
+    override def keyValue[V: ToValue](key: Name, value: V): Field = Field.keyValue(key.value, ToValue(value))
+    override def value[V: ToValue](key: Name, value: V): Field = Field.keyValue(key.value, ToValue(value))
+
+    override def value[V: ToValue](tuple: (Name, V)): Field = Field.value(tuple._1.value, ToValue(tuple._2))
+    override def keyValue[V: ToValue](tuple: (Name, V)): Field = Field.keyValue(tuple._1.value, ToValue(tuple._2))
+  }
+
+  object RefinedFieldBuilder extends RefinedFieldBuilder
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,8 @@ lazy val api = (project in file("api"))
     libraryDependencies += "com.tersesystems.echopraxia" % "api"                % echopraxiaVersion,
     libraryDependencies += "org.scala-lang.modules"     %% "scala-java8-compat" % "1.0.2",
     libraryDependencies ++= compatLibraries(scalaVersion.value),
+    // tests
+    libraryDependencies += "eu.timepit"                 %% "refined" % "0.10.3" % Test,
     libraryDependencies += "org.scalatest"              %% "scalatest" % "3.2.12"      % Test
   )
 


### PR DESCRIPTION
Add a `Name` type, and have `FieldBuilder` use a specialized `Name = String` and implement the `Field.keyValue` / `Field.value` mapping.

This allows for different kinds of field builders that may used [refined types](https://github.com/fthomas/refined) or have specialized names for better control over field names.