### PR TITLE
Add more implicit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ bin/
 target/
 
 *.log
+
+.uuid

--- a/api/src/test/scala-2.13/com/tersesystems/echopraxia/plusscala/api/IterableSpec.scala
+++ b/api/src/test/scala-2.13/com/tersesystems/echopraxia/plusscala/api/IterableSpec.scala
@@ -1,0 +1,86 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api.{Attributes, Field, Value}
+import com.tersesystems.echopraxia.plusscala.api.LoggingBase._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.format.{DateTimeFormatter, FormatStyle}
+import java.time.{Instant, LocalDateTime, ZoneOffset}
+import scala.collection.JavaConverters._
+
+// The tests here compile in 2.13 but do not compile in 2.12
+class IterableSpec extends AnyWordSpec with Matchers with LoggingBase {
+
+  implicit def iterableToArrayValue[V: ToValue]: ToArrayValue[Iterable[V]] = ToArrayValue.iterableToArrayValue[V]
+
+  "iterable" should {
+    implicit val instantToValue: ToValue[Instant] = instant => ToValue(instant.toString)
+
+    // Show a human readable toString
+    trait ToStringFormat[T] extends ToValueAttribute[T] {
+      override def toAttributes(value: Value[_]): Attributes = withAttributes(withStringFormat(value))
+    }
+
+    // XXX check array depends on implicit
+    // XXX check immutable iterable depends on implicit
+    // XXX check mutable iterable depends on implicit
+    // XXX check identity implicit
+
+    "work for primitives" in {
+      val seq: Seq[Int] = Seq(1,2,3)
+      val field: Field = "test" -> seq
+      field.name must be("test")
+      field.value must be(Value.array(seq.map(ToValue(_)).asJava))
+      field.toString must be("test=[1, 2, 3]")
+    }
+
+    "work for objects" in {
+      val instant1 = Instant.ofEpochMilli(0)
+      val instant2 = Instant.ofEpochMilli(1000000)
+      val field: Field = "test" -> Seq(instant1, instant2)
+      field.toString must be("test=[1970-01-01T00:00:00Z, 1970-01-01T00:16:40Z]")
+    }
+
+    "work for objects with custom attributes" in {
+      implicit val readableInstant: ToStringFormat[Instant] = (v: Instant) => {
+        val datetime = LocalDateTime.ofInstant(v, ZoneOffset.UTC)
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+        ToValue(formatter.format(datetime))
+      }
+
+      val instant1 = Instant.ofEpochMilli(0)
+      val instant2 = Instant.ofEpochMilli(1000000)
+      val field: Field = "test" -> Seq(instant1, instant2)
+      field.toString must be("test=[1/1/70, 12:00 AM, 1/1/70, 12:16 AM]")
+    }
+
+    "work with set" in {
+      val instant1 = Instant.ofEpochMilli(0)
+      val instant2 = Instant.ofEpochMilli(1000000)
+      val field: Field = "test" -> Set(instant1, instant2)
+      field.toString must be("test=[1970-01-01T00:00:00Z, 1970-01-01T00:16:40Z]")
+    }
+
+    "work with fields using ToArrayValue" in {
+      import ToObjectValue.fieldToObjectValue // why does this need an explicit import here?
+      val instant1 = Instant.ofEpochMilli(0)
+      val instant2 = Instant.ofEpochMilli(1000000)
+
+      val fields = Seq[Field]("instant1" -> instant1, "instant2" -> instant2)
+      val field: Field = "test" -> ToArrayValue(fields)
+      field.toString must be("test=[{instant1=1970-01-01T00:00:00Z}, {instant2=1970-01-01T00:16:40Z}]")
+    }
+
+    "work with fields with just plain fields" in {
+      val instant1 = Instant.ofEpochMilli(0)
+      val instant2 = Instant.ofEpochMilli(1000000)
+
+      import ToArrayValue._
+      val fields = Seq[Field]("instant1" -> instant1, "instant2" -> instant2)
+      val field: Field = "test" -> fields
+      field.toString must be("test=[{instant1=1970-01-01T00:00:00Z}, {instant2=1970-01-01T00:16:40Z}]")
+    }
+  }
+
+}

--- a/api/src/test/scala-2.13/com/tersesystems/echopraxia/plusscala/api/OptionSpec.scala
+++ b/api/src/test/scala-2.13/com/tersesystems/echopraxia/plusscala/api/OptionSpec.scala
@@ -1,0 +1,56 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api.{Attributes, Field, Value}
+import com.tersesystems.echopraxia.plusscala.api.LoggingBase._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.format.{DateTimeFormatter, FormatStyle}
+import java.time.{Instant, LocalDateTime, ZoneOffset}
+
+// The tests here compile in 2.13 but do not compile in 2.12
+class OptionSpec extends AnyWordSpec with Matchers with LoggingBase {
+  implicit val instantToValue: ToValue[Instant] = instant => ToValue(instant.toString)
+
+  // Show a human readable toString
+  trait ToStringFormat[T] extends ToValueAttribute[T] {
+    override def toAttributes(value: Value[_]): Attributes = withAttributes(withStringFormat(value))
+  }
+
+  "option" should {
+
+    "work with primitives" in {
+      val field: Field = "test" -> Option(1)
+      field.toString must be("test=1")
+    }
+
+    "work with Some" in {
+      val field: Field = "test" -> Some(1)
+      field.toString must be("test=1")
+    }
+
+    "work with None" in {
+      // None must take priority over ToArray
+      // this doesn't work
+      //val field: Field = "test" -> None
+      // This does work but is ugly
+      val field: Field = "test" -> ToValue(None)
+      field.toString must be("test=null")
+    }
+
+    "work with objects" in {
+      val field: Field = "test" -> Option(Instant.ofEpochMilli(0))
+      field.toString must be("test=1970-01-01T00:00:00Z")
+    }
+
+    "work with custom attributes" in {
+      implicit val readableInstant: ToStringFormat[Instant] = (v: Instant) => {
+        val datetime = LocalDateTime.ofInstant(v, ZoneOffset.UTC)
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+        ToValue(formatter.format(datetime))
+      }
+      val field: Field = "test" -> Option(Instant.ofEpochMilli(0))
+      field.toString must be("test=1/1/70, 12:00 AM")
+    }
+  }
+}

--- a/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/EitherSpec.scala
+++ b/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/EitherSpec.scala
@@ -1,0 +1,57 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api.{Attributes, Field, Value}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.format.{DateTimeFormatter, FormatStyle}
+import java.time.{Instant, LocalDateTime, ZoneOffset}
+import java.util.UUID
+
+import LoggingBase._
+
+class EitherSpec extends AnyWordSpec with Matchers with LoggingBase {
+
+  "either" should {
+
+    "work with Left" in {
+      val field: Field = "test" -> Left("left")
+      field.name must be("test")
+      field.value must be(Value.string("left"))
+    }
+
+    "work with Right" in {
+      val field: Field = "test" -> Right("right")
+      field.name must be("test")
+      field.value must be(Value.string("right"))
+    }
+
+    "work with Either" in {
+      val either: Either[Int, String] = Right("right")
+      val field: Field = "test" -> either
+      field.name must be("test")
+      field.value must be(Value.string("right"))
+    }
+
+    "work with a custom attribute" in {
+      implicit val uuidToValue: ToValue[UUID] = uuid => ToValue(uuid.toString)
+      implicit val instantToValue: ToValue[Instant] = instant => ToValue(instant.toString)
+
+      // Show a human readable toString for instant
+      trait ToStringFormat[T] extends ToValueAttribute[T] {
+        override def toAttributes(value: Value[_]): Attributes = withAttributes(withStringFormat(value))
+      }
+
+      implicit val readableInstant: ToStringFormat[Instant] = (v: Instant) => {
+        val datetime = LocalDateTime.ofInstant(v, ZoneOffset.UTC)
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+        ToValue(formatter.format(datetime))
+      }
+
+      val either: Either[UUID, Instant] = Right(Instant.ofEpochMilli(0))
+      val field: Field = "test" -> either
+      field.toString must be("test=1/1/70, 12:00 AM")
+    }
+  }
+
+}

--- a/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/LoggingBase.scala
+++ b/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/LoggingBase.scala
@@ -1,0 +1,159 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api._
+import com.tersesystems.echopraxia.spi.{EchopraxiaService, FieldConstants, FieldCreator, PresentationHintAttributes}
+
+import scala.collection.JavaConverters._
+
+import scala.language.implicitConversions
+import scala.reflect.{ClassTag, classTag}
+
+// This trait should be extended for domain model classes
+trait LoggingBase extends ValueTypeClasses with OptionValueTypes with EitherValueTypes {
+
+  // Provides a default name for a field if not provided
+  trait ToName[-T] {
+    def toName(t: T): String
+  }
+
+  object ToName {
+    def create[T](name: String): ToName[T] = _ => name
+  }
+
+  // Provides easier packaging for ToName and ToValue
+  trait ToLog[-TF] {
+    def toName: ToName[TF]
+    def toValue: ToValue[TF]
+  }
+
+  object ToLog {
+
+    def create[TF](name: String, valueFunction: TF => Value[_]): ToLog[TF] = new ToLog[TF] {
+      override val toName: ToName[TF] = ToName.create(name)
+      override val toValue: ToValue[TF] = t => valueFunction(t)
+    }
+
+    def createFromClass[TF: ClassTag](valueFunction: TF => Value[_]): ToLog[TF] = new ToLog[TF] {
+      override val toName: ToName[TF] = ToName.create(classTag[TF].runtimeClass.getName)
+      override val toValue: ToValue[TF] = t => valueFunction(t)
+    }
+  }
+
+  // Allows custom attributes on fields through implicits
+  trait ToValueAttribute[-T] {
+    def toValue(v: T): Value[_]
+
+    def toAttributes(value: Value[_]): Attributes
+  }
+
+  trait LowPriorityToValueAttributeImplicits {
+    implicit def optionValueFormat[TV: ToValueAttribute]: ToValueAttribute[Option[TV]] = new ToValueAttribute[Option[TV]] {
+      override def toValue(v: Option[TV]): Value[_] = v match {
+        case Some(tv) =>
+          val ev = implicitly[ToValueAttribute[TV]]
+          ev.toValue(tv)
+        case None => Value.nullValue()
+      }
+
+      override def toAttributes(value: Value[_]): Attributes = implicitly[ToValueAttribute[TV]].toAttributes(value)
+    }
+
+    implicit def iterableValueFormat[TV: ToValueAttribute]: ToValueAttribute[Iterable[TV]] = new ToValueAttribute[Iterable[TV]]() {
+      override def toValue(seq: collection.Iterable[TV]): Value[_] = {
+        val list: Seq[Value[_]] = seq.map(el => implicitly[ToValueAttribute[TV]].toValue(el)).toSeq
+        Value.array(list.asJava)
+      }
+
+      override def toAttributes(value: Value[_]): Attributes = implicitly[ToValueAttribute[TV]].toAttributes(value)
+    }
+
+    implicit def eitherToValueAttribute[TVL: ToValueAttribute, TVR: ToValueAttribute]: ToValueAttribute[Either[TVL, TVR]] = new ToValueAttribute[Either[TVL, TVR]] {
+      // This isn't great, but we need to know whether left or right was picked for the attributes
+      // and if we have a parameter (either: Either[]) in the method signature then it doesn't
+      // pick it up?
+      private var optEither: Option[Either[TVL, TVR]] = None
+
+      override def toValue(v: Either[TVL, TVR]): Value[_] = {
+        this.optEither = Some(v)
+        v match {
+          case Left(l) => implicitly[ToValueAttribute[TVL]].toValue(l)
+          case Right(r) => implicitly[ToValueAttribute[TVR]].toValue(r)
+        }
+      }
+
+      override def toAttributes(value: Value[_]): Attributes = {
+        // hack hack hack hack
+        optEither match {
+          case Some(either) =>
+            either match {
+              case Left(_) =>
+                val left = implicitly[ToValueAttribute[TVL]]
+                left.toAttributes(value)
+              case Right(_) =>
+                val right = implicitly[ToValueAttribute[TVR]]
+                right.toAttributes(value)
+            }
+          case None =>
+            // should never get here
+            Attributes.empty()
+        }
+      }
+    }
+
+    // default low priority implicit that gets applied if nothing is found
+    implicit def empty[TV]: ToValueAttribute[TV] = new ToValueAttribute[TV] {
+      override def toValue(v: TV): Value[_] = Value.nullValue()
+      override def toAttributes(value: Value[_]): Attributes = Attributes.empty()
+    }
+  }
+
+  object ToValueAttribute extends LowPriorityToValueAttributeImplicits
+
+  // implicit conversion from a ToLog to a ToValue
+  implicit def convertToLogToValue[TL: ToLog]: ToValue[TL] = implicitly[ToLog[TL]].toValue
+
+  // implicit conversion from a ToLog to a ToName
+  implicit def convertToLogToName[TL: ToLog]: ToName[TL] = implicitly[ToLog[TL]].toName
+
+  // Convert a tuple into a field.  This does most of the heavy lifting.
+  // i.e logger.info("foo" -> foo) becomes logger.info(Field.keyValue("foo", ToValue(foo)))
+  implicit def tupleToField[TV: ToValue](tuple: (String, TV))(implicit va: ToValueAttribute[TV]): Field = keyValue(tuple._1, tuple._2)
+
+  // Convert an object with implicit ToValue and ToName to a field.
+  // i.e. logger.info(foo) becomes logger.info(Field.keyValue(ToName[Foo].toName, ToValue(foo)))
+  implicit def nameAndValueToField[TV: ToValue: ToName](value: TV)(implicit va: ToValueAttribute[TV]): Field =
+    keyValue(implicitly[ToName[TV]].toName(value), value)
+
+  // All exceptions should use "exception" field constant by default
+  implicit def throwableToName[T <: Throwable]: ToName[T] = ToName.create(FieldConstants.EXCEPTION)
+
+  // Creates a field, this is private so it's not exposed to traits that extend this
+  private def keyValue[TV: ToValue](name: String, tv: TV)(implicit va: ToValueAttribute[TV]): Field = {
+    LoggingBase.fieldCreator.create(name, ToValue(tv), va.toAttributes(va.toValue(tv)))
+  }
+}
+
+object LoggingBase {
+  val fieldCreator: FieldCreator[PresentationField] = EchopraxiaService.getInstance.getFieldCreator(classOf[PresentationField])
+
+  def withAttributes(seq: Attribute[_]*): Attributes = {
+    Attributes.create(seq.asJava)
+  }
+
+  // Add a custom string format attribute using the passed in value
+  def withStringFormat(value: Value[_]): Attribute[_] = {
+    PresentationHintAttributes.withToStringFormat(new SimpleFieldVisitor() {
+      override def visit(f: Field): Field = Field.keyValue(f.name(), value)
+    })
+  }
+
+  def withDisplayName(name: String): Attribute[_] = PresentationHintAttributes.withDisplayName(name)
+
+  def abbreviateAfter(after: Int): Attribute[_] = PresentationHintAttributes.abbreviateAfter(after)
+
+  def elided: Attribute[_] = PresentationHintAttributes.asElided()
+
+  def asValueOnly: Attribute[_] = PresentationHintAttributes.asValueOnly()
+
+  def asCardinal: Attribute[_] = PresentationHintAttributes.asCardinal()
+}

--- a/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/NameSpec.scala
+++ b/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/NameSpec.scala
@@ -1,0 +1,45 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api.{Attributes, Field, Value}
+import com.tersesystems.echopraxia.plusscala.api.LoggingBase._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.UUID
+
+class NameSpec extends AnyWordSpec with Matchers with LoggingBase {
+
+  trait ToDerp[T] extends ToValueAttribute[T] {
+    override def toAttributes(value: Value[_]): Attributes = withAttributes(withDisplayName("derp"))
+  }
+
+  "named fields" should {
+
+    "work with ToName" in {
+      implicit val uuidToName: ToName[UUID] = ToName.create("uuid")
+      implicit val uuidToValue: ToValue[UUID] = uuid => ToValue(uuid.toString)
+
+      val field: Field = UUID.randomUUID
+      field.name must be("uuid")
+    }
+
+    "work with ToLog" in {
+      implicit val uuidToLog: ToLog[UUID] = ToLog.create("uuid", uuid => ToValue(uuid.toString))
+
+      val field: Field = UUID.randomUUID
+      field.name must be("uuid")
+    }
+
+    "work with exceptions" in {
+      val field: Field = new IllegalStateException()
+      field.name must be("exception")
+    }
+
+    "work with displayName" in {
+      implicit def exceptionToDerp[T <: Throwable]: ToDerp[T] = e => ToValue(e)
+
+      val field: Field = new IllegalStateException()
+      field.toString must be(""""derp"=java.lang.IllegalStateException""")
+    }
+  }
+}

--- a/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/ObjectSpec.scala
+++ b/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/ObjectSpec.scala
@@ -1,0 +1,34 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
+
+import com.tersesystems.echopraxia.api.Field
+import com.tersesystems.echopraxia.api.Value
+
+import scala.collection.JavaConverters._
+
+class ObjectSpec extends AnyFunSpec with Matchers with LoggingBase {
+
+  describe("object") {
+
+    it("work with a single field") {
+      import ToObjectValue._
+      val field: Field = "test" -> ("foo" -> "bar": Field)
+      field.name must be("test")
+      val objectValue: Value.ObjectValue = field.value().asObject()
+      val fields: Seq[Field] = objectValue.raw.asScala.toSeq
+      fields.head.name must be("foo")
+    }
+
+    it("work with multiple fields") {
+      val field: Field = "test" -> ToObjectValue("foo" -> "bar", "baz" -> "quux")
+      field.name must be("test")
+      val objectValue: Value.ObjectValue = field.value().asObject()
+      val fields: Seq[Field] = objectValue.raw.asScala.toSeq
+      fields(1).name must be("baz")
+    }
+
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,10 @@ def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
         "-Ywarn-dead-code",
         "-Yrangepos",
         "-release",
-        "8"
+        "8",
+        "-Vimplicits",
+        "-Vtype-diffs",
+        "P:splain:Vimplicits-diverging"
       )
     case Some((2, n)) if n == 12 =>
       Seq(


### PR DESCRIPTION
We should be able to create an API that depends on implicit conversion instead of using a field builder.

The problem is that some tests require explicit imports in 2.13 even though they *should* work and some tests work in 2.13 but not 2.12.

Add the tests, add the tek/splain compiler warnings for implicits.
