### PR TITLE
move sourcecode into api

### DIFF
--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
@@ -123,7 +123,10 @@ trait StringNameTupleFieldBuilder extends TupleFieldBuilder {
     val attributes = ev.toAttributes(ev.toValue(tuple._2)).plus(PresentationHintAttributes.asValueOnly())
     Utils.newField(tuple._1, ToValue(tuple._2), attributes, fieldClass)
   }
+}
 
+trait SourceCodeFieldBuilder extends ValueTypeClasses with SourceCodeImplicits with HasFieldClass {
+  def sourceCode(sourceCode: SourceCode): FieldType
 }
 
 /**
@@ -137,6 +140,7 @@ trait FieldBuilderBase
     with StringNameTupleFieldBuilder
     with PrimitiveTupleFieldBuilder
     with PrimitiveArgsFieldBuilder
+    with SourceCodeFieldBuilder
 
 /**
  * A field builder that uses PresentationField.
@@ -144,6 +148,8 @@ trait FieldBuilderBase
 trait PresentationFieldBuilder extends FieldBuilderBase {
   override type FieldType = PresentationField
   override protected def fieldClass: Class[PresentationField] = classOf[PresentationField]
+
+  override def sourceCode(sourceCode: SourceCode): PresentationField = keyValue(ToName(sourceCode), ToValue(sourceCode))
 }
 
 /**
@@ -154,6 +160,8 @@ object PresentationFieldBuilder extends PresentationFieldBuilder
 trait FieldBuilder extends FieldBuilderBase {
   override type FieldType = Field
   override protected def fieldClass: Class[Field] = classOf[Field]
+
+  override def sourceCode(sourceCode: SourceCode): Field = keyValue(ToName(sourceCode), ToValue(sourceCode))
 }
 
 /**

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/SourceCode.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/SourceCode.scala
@@ -1,0 +1,23 @@
+package com.tersesystems.echopraxia.plusscala.api
+
+import com.tersesystems.echopraxia.api.Attributes
+import com.tersesystems.echopraxia.plusscala.spi.Utils.newField
+
+import sourcecode._
+
+case class SourceCode(line: Line, file: File, enclosing: Enclosing)
+
+object SourceCode {
+  implicit val sourceCodeToName: ToName[SourceCode] = ToName.create("sourcecode")
+}
+
+trait SourceCodeImplicits { self: ValueTypeClasses =>
+
+  implicit val sourceCodeToValue: ToValue[SourceCode] = { sc =>
+    ToObjectValue(
+      newField("file", ToValue(sc.file.value), Attributes.empty),
+      newField("line", ToValue(sc.line.value: java.lang.Integer), Attributes.empty),
+      newField("enclosing", ToValue(sc.enclosing.value), Attributes.empty)
+    )
+  }
+}

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/ThrowableToName.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/ThrowableToName.scala
@@ -7,3 +7,5 @@ trait ThrowableToName {
   // All exceptions should use "exception" field constant by default
   implicit def throwableToName[T <: Throwable]: ToName[T] = ToName.create(FieldConstants.EXCEPTION)
 }
+
+object ThrowableToName extends ThrowableToName

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/ToName.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/ToName.scala
@@ -6,5 +6,8 @@ trait ToName[-T] {
 }
 
 object ToName {
+  
+  def apply[T: ToName](t: T): String = implicitly[ToName[T]].toName(t)
+  
   def create[T](name: String): ToName[T] = _ => name
 }

--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,7 @@ lazy val api = (projectMatrix in file("api"))
     libraryDependencies += "com.tersesystems.echopraxia" % "api"                % echopraxiaVersion,
     libraryDependencies += "org.scala-lang.modules"     %% "scala-java8-compat" % scalaJavaVersion,
     libraryDependencies ++= compatLibraries(scalaVersion.value),
+    libraryDependencies += "com.lihaoyi" %% "sourcecode" % sourceCodeVersion,
     // tests
     libraryDependencies += "eu.timepit"    %% "refined"   % refinedVersion   % Test,
     libraryDependencies += "org.scalatest" %% "scalatest" % scalatestVersion % Test,
@@ -121,7 +122,6 @@ lazy val logger = (projectMatrix in file("logger"))
   .settings(
     name := "logger",
     scalacOptions := scalacOptionsVersion(scalaVersion.value),
-    libraryDependencies += "com.lihaoyi" %% "sourcecode" % sourceCodeVersion,
     //
     libraryDependencies += "com.tersesystems.echopraxia" % "logstash"                 % echopraxiaVersion     % Test,
     libraryDependencies += "org.scalatest"              %% "scalatest"                % scalatestVersion      % Test,
@@ -208,8 +208,6 @@ lazy val traceLogger = (projectMatrix in file("trace"))
   .settings(
     name := "trace-logger",
     scalacOptions := scalacOptionsVersion(scalaVersion.value),
-    //
-    libraryDependencies += "com.lihaoyi" %% "sourcecode" % sourceCodeVersion,
     //
     libraryDependencies += "com.tersesystems.echopraxia" % "logstash"                 % echopraxiaVersion     % Test,
     libraryDependencies += "ch.qos.logback"              % "logback-classic"          % logbackClassicVersion % Test,

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
@@ -2,10 +2,9 @@ package com.tersesystems.echopraxia.plusscala
 
 import com.tersesystems.echopraxia.api.FieldBuilderResult.list
 import com.tersesystems.echopraxia.api.{Field, FieldBuilderResult, Level, Value}
-import com.tersesystems.echopraxia.api.Level._
-import com.tersesystems.echopraxia.plusscala.api.Condition
-import com.tersesystems.echopraxia.plusscala.spi.DefaultMethodsSupport
-import com.tersesystems.echopraxia.plusscala.spi.LoggerSupport
+import com.tersesystems.echopraxia.api.Level.{TRACE, DEBUG, INFO, WARN, ERROR}
+import com.tersesystems.echopraxia.plusscala.api.{Condition, PresentationFieldBuilder, SourceCode}
+import com.tersesystems.echopraxia.plusscala.spi.{DefaultMethodsSupport, LoggerSupport, Utils}
 import com.tersesystems.echopraxia.spi.{CoreLogger, FieldConstants, Utilities}
 import sourcecode.{Enclosing, File, Line}
 
@@ -237,20 +236,14 @@ class LoggerMethodWithLevel[FB](level: Level, core: CoreLogger, fieldBuilder: FB
   // Internal methods
 
   private def sourceCodeField(implicit line: Line, file: File, enc: Enclosing): Field = {
-    Field
-      .keyValue(
-        "sourcecode",
-        Value.`object`(
-          Field.keyValue("file", Value.string(file.value)),
-          Field.keyValue("line", Value.number(line.value: java.lang.Integer)),
-          Field.keyValue("enclosing", Value.string(enc.value))
-        )
-      )
+    val sc = SourceCode(line, file, enc)
+    val fb = PresentationFieldBuilder
+    fb.sourceCode(sc)
   }
 
   @inline
   protected def onlyException(e: Throwable): FieldBuilderResult = {
-    Field.keyValue(FieldConstants.EXCEPTION, Value.exception(e))
+    val fb = PresentationFieldBuilder
+    fb.exception(e)
   }
-
 }


### PR DESCRIPTION
Add a `SourceCode` case class and implicits to map it to a value and name, add a `fb.sourceCode` to render it to a field.