### PR TITLE
Update to snapshot version 1.4.0-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys._
 import commandmatrix._
 import commandmatrix.extra._
 
-val echopraxiaVersion            = "3.1.2"
+val echopraxiaVersion            = "3.2.0-SNAPSHOT"
 val scalatestVersion             = "3.2.18"
 val logbackClassicVersion        = "1.5.3"
 val logstashVersion              = "7.4"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ addSbtPlugin("com.indoorvivants" % "sbt-commandmatrix" % "0.0.5")
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
 
 // Must use bloop for scala 3
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.15")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.17")
 
 // scalafix
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.3.1-SNAPSHOT"
+ThisBuild / version := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
Use echopraxia 3.2.0-SNAPSHOT, and upgrade this version to 1.4.0-SNAPSHOT.