### PR TITLE
rearrange string to name

### DIFF
--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldBuilder.scala
@@ -137,7 +137,7 @@ trait FieldBuilderBase
 /**
  * A field builder that uses PresentationField.
  */
-trait PresentationFieldBuilder extends FieldBuilderBase {
+trait PresentationFieldBuilder extends FieldBuilderBase with StringToNameImplicits {
   override type FieldType = PresentationField
   override protected def fieldClass: Class[PresentationField] = classOf[PresentationField]
 }
@@ -147,7 +147,7 @@ trait PresentationFieldBuilder extends FieldBuilderBase {
  */
 object PresentationFieldBuilder extends PresentationFieldBuilder
 
-trait FieldBuilder extends FieldBuilderBase {
+trait FieldBuilder extends FieldBuilderBase with StringToNameImplicits {
   override type FieldType = Field
   override protected def fieldClass: Class[Field] = classOf[Field]
 }

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/LoggingBase.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/LoggingBase.scala
@@ -34,3 +34,4 @@ trait LoggingBase
     with EitherValueTypes
     with FutureValueTypes
     with ToFieldTypes
+    with StringToNameImplicits

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/NameTypeClass.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/NameTypeClass.scala
@@ -12,17 +12,17 @@ trait NameTypeClass {
     def toName(t: T): String
   }
 
-  trait LowPriorityToNames {
+  object ToName {
     implicit def throwableToName[T <: Throwable]: ToName[T] = _ => FieldConstants.EXCEPTION
 
     implicit val sourceCodeToName: ToName[SourceCode] = _ => SourceCode.SourceCode
 
-    implicit val stringToName: ToName[String] = identity
-  }
-
-  object ToName extends LowPriorityToNames {
     def option[T: ToName](fallback: T): ToName[Option[T]] = (optT: Option[T]) => apply(optT.getOrElse(fallback))
 
     def apply[T: ToName](t: T): String = implicitly[ToName[T]].toName(t)
   }
+}
+
+trait StringToNameImplicits { this: NameTypeClass =>
+  implicit val stringToName: ToName[String] = identity
 }

--- a/api/src/test/scala-2/com/tersesystems/echopraxia/plusscala/api/RefinedFieldBuilderSpec.scala
+++ b/api/src/test/scala-2/com/tersesystems/echopraxia/plusscala/api/RefinedFieldBuilderSpec.scala
@@ -15,16 +15,21 @@ class RefinedFieldBuilderSpec extends AnyFunSpec with Matchers {
 
     it("should work with java.lang.Byte") {
       val byte = java.lang.Byte.MIN_VALUE
-      fb.keyValue(refineMV[NonEmpty]("byte"), byte)
+      val byteName: fb.Name = refineMV("byte")
+      fb.keyValue(byteName, byte)
     }
 
     it("should work with java.lang.Short") {
       val short = java.lang.Short.MIN_VALUE
-      fb.keyValue(refineMV[NonEmpty]("short"), short)
+      val shortName: fb.Name = refineMV("short")
+      fb.keyValue(shortName, short)
     }
   }
 
-  trait RefinedFieldBuilder extends PresentationFieldBuilder {
+  trait RefinedFieldBuilder extends FieldBuilderBase {
+    override type FieldType = Field
+    override protected def fieldClass: Class[Field] = classOf[Field]
+
     type Name = String Refined NonEmpty
 
     implicit val refinedToName: ToName[Name] = s => s.value


### PR DESCRIPTION
Move `implicit val stringToName: ToName[String]` to its own trait, add it directly to `PresentationFieldBuilder` and `FieldBuilder` so we can set up names that are not strings in fieldbuilder.