### PR TITLE
better option name

### DIFF
--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldConversionImplicits.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/FieldConversionImplicits.scala
@@ -17,6 +17,6 @@ trait FieldConversionImplicits { self: ValueTypeClasses with NameTypeClass =>
   // Creates a field, this is private so it's not exposed to traits that extend this
   @inline
   private def newField[TN: ToName, TV: ToValue](name: TN, tv: TV): Field = {
-    Utils.newField(implicitly[ToName[TN]].toName(name), ToValue(tv), Attributes.empty)
+    Utils.newField(implicitly[ToName[TN]].toName(Option(name)), ToValue(tv), Attributes.empty)
   }
 }

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/NameTypeClass.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/NameTypeClass.scala
@@ -13,7 +13,7 @@ trait NameTypeClass {
 
   @implicitNotFound("Could not find an implicit ToName[${T}]")
   trait ToName[-T] {
-    def toName(t: T): String
+    def toName(t: Option[T]): String
   }
 
   object ToName {
@@ -21,12 +21,12 @@ trait NameTypeClass {
 
     implicit val sourceCodeToName: ToName[SourceCode] = _ => SourceCode.SourceCode
 
-    def option[T: ToName](fallback: T): ToName[Option[T]] = (optT: Option[T]) => apply(optT.getOrElse(fallback))
+    implicit def optNameToName[T: ToName]: ToName[Option[T]] = (t: Option[Option[T]]) => implicitly[ToName[T]].toName(t.flatten)
 
-    def apply[T: ToName](t: T): String = implicitly[ToName[T]].toName(t)
+    def apply[T: ToName](t: T): String = implicitly[ToName[T]].toName(Option(t))
   }
 }
 
 trait StringToNameImplicits extends NameTypeClass {
-  implicit val stringToName: ToName[String] = identity
+  implicit val stringToName: ToName[String] = _.orNull
 }

--- a/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/ToFieldTypes.scala
+++ b/api/src/main/scala/com/tersesystems/echopraxia/plusscala/api/ToFieldTypes.scala
@@ -10,7 +10,7 @@ trait ToFieldTypes { self: ValueTypeClasses with NameTypeClass =>
   }
 
   object ToField {
-    def apply[TF](nameFunction: TF => String, valueFunction: TF => Value[_]): ToField[TF] = new ToField[TF] {
+    def apply[TF](nameFunction: Option[TF] => String, valueFunction: TF => Value[_]): ToField[TF] = new ToField[TF] {
       override val toName: ToName[TF]   = t => nameFunction(t)
       override val toValue: ToValue[TF] = t => valueFunction(t)
     }

--- a/api/src/test/scala-2/com/tersesystems/echopraxia/plusscala/api/RefinedFieldBuilderSpec.scala
+++ b/api/src/test/scala-2/com/tersesystems/echopraxia/plusscala/api/RefinedFieldBuilderSpec.scala
@@ -32,7 +32,7 @@ class RefinedFieldBuilderSpec extends AnyFunSpec with Matchers {
 
     type Name = String Refined NonEmpty
 
-    implicit val refinedToName: ToName[Name] = s => s.value
+    implicit val refinedToName: ToName[Name] = _.map(_.value).orNull
   }
 
   object RefinedFieldBuilder extends RefinedFieldBuilder

--- a/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/NameSpec.scala
+++ b/api/src/test/scala/com/tersesystems/echopraxia/plusscala/api/NameSpec.scala
@@ -6,7 +6,6 @@ import enumeratum._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -41,8 +40,7 @@ class NameSpec extends AnyWordSpec with Matchers with Logging {
     }
 
     "work with option" in {
-      implicit val instantName: ToName[ZonedDateTime]           = zdt => zdt.getZone.toString
-      implicit val optStringName: ToName[Option[ZonedDateTime]] = ToName.option(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+      implicit val zonedName: ToName[ZonedDateTime]           = optZone => optZone.map(_.getZone.toString).orNull
       implicit val zonedDateTimeToValue: ToValue[ZonedDateTime] = zdt => ToValue(zdt.toString)
 
       val optInstant: Option[ZonedDateTime] = Some(ZonedDateTime.now(ZoneId.of("America/Los_Angeles")))
@@ -51,17 +49,16 @@ class NameSpec extends AnyWordSpec with Matchers with Logging {
     }
 
     "works with none" in {
-      implicit val instantName: ToName[ZonedDateTime]           = zdt => zdt.getZone.toString
-      implicit val optStringName: ToName[Option[ZonedDateTime]] = ToName.option(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+      implicit val instantName: ToName[ZonedDateTime]           = optZone => optZone.map(_.getZone.toString).orNull
       implicit val zonedDateTimeToValue: ToValue[ZonedDateTime] = zdt => ToValue(zdt.toString)
 
       val optInstant: Option[ZonedDateTime] = None
       val field: Field                      = optInstant -> optInstant
-      field.name must be("UTC")
+      field.name must be("echopraxia-unknown-1")
     }
 
     "works with enum" in {
-      implicit def enumToName[T <: EnumEntry]: ToName[T] = t => t.entryName
+      implicit def enumToName[T <: EnumEntry]: ToName[T] = _.map(_.entryName).orNull
 
       val field: Field = Names.CreditCard -> "4111 1111 1111 1111"
       field.name() must be("credit_card")

--- a/logger/src/test/scala/com/tersesystems/echopraxia/plusscala/Main.scala
+++ b/logger/src/test/scala/com/tersesystems/echopraxia/plusscala/Main.scala
@@ -6,6 +6,7 @@ import com.tersesystems.echopraxia.plusscala.api.HeterogeneousFieldSupport
 import java.util.Currency
 import java.util.UUID
 import scala.concurrent.Future
+import scala.reflect.ClassTag
 
 object Main {
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
Make `ToName` take an `def toName(t: Option[T]): String` so it can account for the case where there isn't an object.  As a bonus, turning an `ToName[Foo]` is the same as `ToName[Option[Foo]]` as we can just flatten the option implicitly.