### PR TITLE
enforce singleton

### DIFF
--- a/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLogger.scala
+++ b/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLogger.scala
@@ -10,18 +10,18 @@ import com.tersesystems.echopraxia.spi.Utilities
 import java.util.concurrent.Executor
 import scala.compat.java8.FunctionConverters._
 
-trait AsyncLogger[FB] extends AsyncLoggerMethods[FB] with LoggerSupport[FB, AsyncLogger] with DefaultMethodsSupport[FB] {
+trait AsyncLogger[FB <: Singleton] extends AsyncLoggerMethods[FB] with LoggerSupport[FB, AsyncLogger] with DefaultMethodsSupport[FB] {
   def withExecutor(executor: Executor): AsyncLogger[FB]
 }
 
 object AsyncLogger {
 
-  def apply[FB](core: CoreLogger, fieldBuilder: FB): AsyncLogger[FB] = new Impl(core, fieldBuilder)
+  def apply[FB <: Singleton](core: CoreLogger, fieldBuilder: FB): AsyncLogger[FB] = new Impl(core, fieldBuilder)
 
   /**
    * Async Logger with source code enabled.
    */
-  class Impl[FB](val core: CoreLogger, val fieldBuilder: FB) extends AsyncLogger[FB] with DefaultAsyncLoggerMethods[FB] {
+  class Impl[FB <: Singleton](val core: CoreLogger, val fieldBuilder: FB) extends AsyncLogger[FB] with DefaultAsyncLoggerMethods[FB] {
 
     override def name: String = core.getName
 
@@ -48,11 +48,11 @@ object AsyncLogger {
       newCoreLogger = core.withThreadContext(Utilities.threadContext())
     )
 
-    override def withFieldBuilder[T](newBuilder: T): AsyncLogger[T] =
+    override def withFieldBuilder[T <: Singleton](newBuilder: T): AsyncLogger[T] =
       newLogger(newFieldBuilder = newBuilder)
 
     @inline
-    private def newLogger[T](
+    private def newLogger[T <: Singleton](
         newCoreLogger: CoreLogger = core,
         newFieldBuilder: T = fieldBuilder
     ): AsyncLogger[T] =
@@ -60,7 +60,7 @@ object AsyncLogger {
 
   }
 
-  trait NoOp[FB] extends AsyncLogger[FB] {
+  trait NoOp[FB <: Singleton] extends AsyncLogger[FB] {
     override def ifTraceEnabled(consumer: Handle => Unit): Unit = {}
 
     override def ifTraceEnabled(condition: Condition)(consumer: Handle => Unit): Unit = {}
@@ -144,7 +144,7 @@ object AsyncLogger {
 
   object NoOp {
 
-    def apply[FB](c: CoreLogger, fb: FB): AsyncLogger[FB] = new NoOp[FB] {
+    def apply[FB <: Singleton](c: CoreLogger, fb: FB): AsyncLogger[FB] = new NoOp[FB] {
       override def name: String = c.getName
 
       override def core: CoreLogger = c

--- a/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLoggerFactory.scala
+++ b/async/src/main/scala/com/tersesystems/echopraxia/plusscala/async/AsyncLoggerFactory.scala
@@ -17,7 +17,7 @@ object AsyncLoggerFactory {
     AsyncLogger(core, fieldBuilder)
   }
 
-  def getLogger[FB](name: String, fieldBuilder: FB): AsyncLogger[FB] = {
+  def getLogger[FB <: Singleton](name: String, fieldBuilder: FB): AsyncLogger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
     AsyncLogger(core, fieldBuilder)
   }
@@ -27,7 +27,7 @@ object AsyncLoggerFactory {
     AsyncLogger(core, fieldBuilder)
   }
 
-  def getLogger[FB](clazz: Class[_], fieldBuilder: FB): AsyncLogger[FB] = {
+  def getLogger[FB <: Singleton](clazz: Class[_], fieldBuilder: FB): AsyncLogger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
     AsyncLogger(core, fieldBuilder)
   }
@@ -37,7 +37,7 @@ object AsyncLoggerFactory {
     AsyncLogger(core, fieldBuilder)
   }
 
-  def getLogger[FB](fieldBuilder: FB): AsyncLogger[FB] = {
+  def getLogger[FB <: Singleton](fieldBuilder: FB): AsyncLogger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
     AsyncLogger(core, fieldBuilder)
   }

--- a/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLogger.scala
+++ b/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLogger.scala
@@ -9,13 +9,18 @@ import com.tersesystems.echopraxia.spi.Utilities
 
 import scala.compat.java8.FunctionConverters._
 
-trait FlowLogger[FB <: FlowFieldBuilder] extends FlowLoggerMethods[FB] with LoggerSupport[FB, FlowLogger] with DefaultMethodsSupport[FB]
+trait FlowLogger[FB <: FlowFieldBuilder with Singleton]
+    extends FlowLoggerMethods[FB]
+    with LoggerSupport[FB, FlowLogger]
+    with DefaultMethodsSupport[FB]
 
 object FlowLogger {
 
-  def apply[FB <: FlowFieldBuilder](c: CoreLogger, fb: FB): FlowLogger[FB] = new Impl(c, fb)
+  def apply[FB <: FlowFieldBuilder with Singleton](c: CoreLogger, fb: FB): FlowLogger[FB] = new Impl(c, fb)
 
-  class Impl[FB <: FlowFieldBuilder](val core: CoreLogger, val fieldBuilder: FB) extends FlowLogger[FB] with DefaultFlowLoggerMethods[FB] {
+  class Impl[FB <: FlowFieldBuilder with Singleton](val core: CoreLogger, val fieldBuilder: FB)
+      extends FlowLogger[FB]
+      with DefaultFlowLoggerMethods[FB] {
 
     override def name: String = core.getName
 
@@ -38,7 +43,7 @@ object FlowLogger {
       )
     }
 
-    def withFieldBuilder[NEWFB <: FlowFieldBuilder](newFieldBuilder: NEWFB): FlowLogger[NEWFB] = {
+    def withFieldBuilder[NEWFB <: FlowFieldBuilder with Singleton](newFieldBuilder: NEWFB): FlowLogger[NEWFB] = {
       newLogger(newFieldBuilder = newFieldBuilder)
     }
 
@@ -48,7 +53,7 @@ object FlowLogger {
     }
 
     @inline
-    private def newLogger[T <: FlowFieldBuilder](
+    private def newLogger[T <: FlowFieldBuilder with Singleton](
         newCoreLogger: CoreLogger = core,
         newFieldBuilder: T = fieldBuilder
     ): FlowLogger[T] =
@@ -56,7 +61,7 @@ object FlowLogger {
   }
 
   object NoOp {
-    def apply[FB <: FlowFieldBuilder](c: CoreLogger, fb: FB): FlowLogger[FB] = new NoOp[FB] {
+    def apply[FB <: FlowFieldBuilder with Singleton](c: CoreLogger, fb: FB): FlowLogger[FB] = new NoOp[FB] {
       override def name: String = c.getName
 
       override def core: CoreLogger = c
@@ -73,7 +78,7 @@ object FlowLogger {
     }
   }
 
-  trait NoOp[FB <: FlowFieldBuilder] extends FlowLogger[FB] {
+  trait NoOp[FB <: FlowFieldBuilder with Singleton] extends FlowLogger[FB] {
     override def trace[B: ToValue](attempt: => B): B                       = attempt
     override def trace[B: ToValue](condition: Condition)(attempt: => B): B = attempt
     override def debug[B: ToValue](attempt: => B): B                       = attempt

--- a/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLoggerFactory.scala
+++ b/flow/src/main/scala/com/tersesystems/echopraxia/plusscala/flow/FlowLoggerFactory.scala
@@ -6,34 +6,34 @@ import com.tersesystems.echopraxia.spi.CoreLoggerFactory
 object FlowLoggerFactory {
   val FQCN: String = classOf[DefaultFlowLoggerMethods[_]].getName
 
-  val fieldBuilder: FlowFieldBuilder = DefaultFlowFieldBuilder
+  val fieldBuilder: DefaultFlowFieldBuilder.type = DefaultFlowFieldBuilder
 
-  def getLogger(name: String): FlowLogger[FlowFieldBuilder] = {
+  def getLogger(name: String): FlowLogger[DefaultFlowFieldBuilder.type] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
     FlowLogger(core, fieldBuilder)
   }
 
-  def getLogger[FB <: FlowFieldBuilder](name: String, fieldBuilder: FB): FlowLogger[FB] = {
+  def getLogger[FB <: FlowFieldBuilder with Singleton](name: String, fieldBuilder: FB): FlowLogger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
     FlowLogger(core, fieldBuilder)
   }
 
-  def getLogger(clazz: Class[_]): FlowLogger[FlowFieldBuilder] = {
+  def getLogger(clazz: Class[_]): FlowLogger[DefaultFlowFieldBuilder.type] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
     FlowLogger(core, fieldBuilder)
   }
 
-  def getLogger[FB <: FlowFieldBuilder](clazz: Class[_], fieldBuilder: FB): FlowLogger[FB] = {
+  def getLogger[FB <: FlowFieldBuilder with Singleton](clazz: Class[_], fieldBuilder: FB): FlowLogger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
     FlowLogger(core, fieldBuilder)
   }
 
-  def getLogger: FlowLogger[FlowFieldBuilder] = {
+  def getLogger: FlowLogger[DefaultFlowFieldBuilder.type] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
     FlowLogger(core, fieldBuilder)
   }
 
-  def getLogger[FB <: FlowFieldBuilder](fieldBuilder: FB): FlowLogger[FB] = {
+  def getLogger[FB <: FlowFieldBuilder with Singleton](fieldBuilder: FB): FlowLogger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
     FlowLogger(core, fieldBuilder)
   }

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/Logger.scala
@@ -22,15 +22,15 @@ import sourcecode.Line
 
 import scala.compat.java8.FunctionConverters.enrichAsJavaFunction
 
-trait Logger[FB] extends LoggerMethods[FB] with LoggerSupport[FB, Logger] with DefaultMethodsSupport[FB]
+trait Logger[FB <: Singleton] extends LoggerMethods[FB] with LoggerSupport[FB, Logger] with DefaultMethodsSupport[FB]
 
 object Logger {
 
-  def apply[FB](core: CoreLogger, fieldBuilder: FB): Logger[FB] = new Impl[FB](core, fieldBuilder)
+  def apply[FB <: Singleton](core: CoreLogger, fieldBuilder: FB): Logger[FB] = new Impl[FB](core, fieldBuilder)
 
   /**
    */
-  class Impl[FB](val core: CoreLogger, val fieldBuilder: FB) extends Logger[FB] {
+  class Impl[FB <: Singleton](val core: CoreLogger, val fieldBuilder: FB) extends Logger[FB] {
 
     private val traceMethod: LoggerMethod[FB] = new LoggerMethodWithLevel(Level.TRACE, core, fieldBuilder)
     private val debugMethod: LoggerMethod[FB] = new LoggerMethodWithLevel(Level.DEBUG, core, fieldBuilder)
@@ -61,12 +61,12 @@ object Logger {
       )
     }
 
-    override def withFieldBuilder[NEWFB](newFieldBuilder: NEWFB): Logger[NEWFB] = {
+    override def withFieldBuilder[NEWFB <: Singleton](newFieldBuilder: NEWFB): Logger[NEWFB] = {
       newLogger(newFieldBuilder = newFieldBuilder)
     }
 
     @inline
-    private def newLogger[T](
+    private def newLogger[T <: Singleton](
         newCoreLogger: CoreLogger = core,
         newFieldBuilder: T = fieldBuilder
     ): Logger[T] =
@@ -150,7 +150,7 @@ object Logger {
     def error: LoggerMethod[FB] = errorMethod
   }
 
-  trait NoOp[FB] extends Logger[FB] {
+  trait NoOp[FB <: Singleton] extends Logger[FB] {
     override def isTraceEnabled: Boolean = false
 
     override def isTraceEnabled(condition: Condition): Boolean = false
@@ -184,7 +184,7 @@ object Logger {
   }
 
   object NoOp {
-    def apply[FB](c: CoreLogger, fb: FB): NoOp[FB] = new NoOp[FB] {
+    def apply[FB <: Singleton](c: CoreLogger, fb: FB): NoOp[FB] = new NoOp[FB] {
       override def name: String = c.getName
 
       override def core: CoreLogger = c

--- a/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/LoggerFactory.scala
+++ b/logger/src/main/scala/com/tersesystems/echopraxia/plusscala/LoggerFactory.scala
@@ -22,12 +22,12 @@ object LoggerFactory {
     Logger(core, fieldBuilder)
   }
 
-  def getLogger[FB](name: String, fieldBuilder: FB): Logger[FB] = {
+  def getLogger[FB <: Singleton](name: String, fieldBuilder: FB): Logger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, name)
     Logger(core, fieldBuilder)
   }
 
-  def getLogger[FB](clazz: Class[_], fieldBuilder: FB): Logger[FB] = {
+  def getLogger[FB <: Singleton](clazz: Class[_], fieldBuilder: FB): Logger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, clazz.getName)
     Logger(core, fieldBuilder)
   }
@@ -37,7 +37,7 @@ object LoggerFactory {
     Logger(core, fieldBuilder)
   }
 
-  def getLogger[FB](fieldBuilder: FB): Logger[FB] = {
+  def getLogger[FB <: Singleton](fieldBuilder: FB): Logger[FB] = {
     val core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName)
     Logger(core, fieldBuilder)
   }


### PR DESCRIPTION
Enforce that loggers must use a field builder that extends `Singleton` so the implicit type resolution picks up extra definitions in the field builder.